### PR TITLE
fix: quantità delle immagini all'interno dei reports 

### DIFF
--- a/server/public/modules/common/service/configService.js
+++ b/server/public/modules/common/service/configService.js
@@ -10,7 +10,6 @@
     const queryDomain = urlParams.get('domain');
 
     config.BACKENDURL = queryDomain ? queryDomain + '/' : 'https://logicawebdev2.snps.it/';
-    console.log('config.BACKENDURL', config.BACKENDURL);
     config.BASEAPIURL = config.BACKENDURL + 'api';
     config.BASEHUBURL = config.BACKENDURL + 'hub';
 

--- a/server/public/modules/report/directives/attachGalleriaReport.js
+++ b/server/public/modules/report/directives/attachGalleriaReport.js
@@ -11,7 +11,7 @@
 
   const loadImages = async ({ idVista, idRecord, nomeRisorsa, foreignKeyVista, xdbApiService, filesPerCampo, idCampo }) => {
     const q = foreignKeyVista ? (foreignKeyVista + '=%25=' + idRecord) : null;
-    const res = await xdbApiService.getVistaRows(idVista, 10, 0, null, q);
+    const res = await xdbApiService.getVistaRows(idVista, -1, 0, null, q);
     const images = (res?.data?.records || []).filter(file => filesPerCampo.isImage(file.nome));
     return Promise.all(images.map(async image => {
       const url = await filesPerCampo

--- a/server/public/modules/xdb/service/xdbApiService.js
+++ b/server/public/modules/xdb/service/xdbApiService.js
@@ -17,15 +17,7 @@
     };
 
     this.getVistaRows = function (idVista, limit, offset, sort, q) {
-      let urlParams = 'limit=' + limit + '&offset=' + offset;
-
-      if (sort) {
-        urlParams += '&orderBy=' + sort;
-      }
-
-      if (q) {
-        urlParams += '&' + q;
-      }
+      const urlParams = [limit ? `limit=${limit}` : "", offset ? `&offset=${offset}` : "", sort ? `&orderBy=${sort}` : "", q ? `&${q}` : ""].filter((string) => string.length > 0).join("");
 
       const url = `${apiURLs.getBasePath()}/${DATABASEURL}/vista-rows/${idVista}?${urlParams}`;
 


### PR DESCRIPTION
## Esigenze fix:
Quando genero un report con delle immagini vengono visualizzate solo 10 immagini. Rendere possibile la visualizzazione di più immagini senza alcun limite.

---
## Cosa comprende questa pr:

- assegnato parametro url limit=-1 per ottenere tutte le immagini di una data vista
- semplificata scrittura dell'url utilizzato in `getValoriCampiScheda()`