### PR TITLE
Feat: possibilità di inserire stile css proveniente da client (Rif.Int. 2025/ 4116)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -49,6 +49,29 @@ const boot = async (app) => {
       cluster,
       logger
     });
+    
+    app.get('/:tenantId/templates/:templateId', async function (req, _res) {
+      const timeZone = req.headers['time-zone'];
+      const domain = req.headers['x-domain'] || 'https://logicawebdev2.snps.it';
+
+      const {
+        tenantId,
+        templateId
+      } = req.params;
+
+       const authResult = await auth.serviceAuth({
+        domain,
+        clientId: CLIENT_ID,
+        clientSecret: CLIENT_SECRET
+       });  
+      
+  const token = req.headers.authorization || authResult.access_token;
+
+    
+      await printer.getApiAddedStyles({ domain, templateId, tenantId, timeZone, token })
+
+      return {url, res: response.json()}
+    })
 
     app.get('/public', async (req, res) => {
       return res.sendFile('index.html');
@@ -128,9 +151,40 @@ const boot = async (app) => {
     app.post('/print/v2/:tenantId/:templateId/:recordId', async (req, res) => {
       await doPrintRequest(req, res, false);
     });
+    
+//     app.get('/:tenantId/templates/:templateId', async function (req, _res) {
+//     const timeZone = req.headers['time-zone'];
+//     const domain = req.headers['x-domain'] || 'logicawebdev2.snps.it';
 
+//     const {
+//       tenantId,
+//       templateId
+//     } = req.params;
+
+//      const authResult = await auth.serviceAuth({
+//       domain,
+//       clientId: CLIENT_ID,
+//       clientSecret: CLIENT_SECRET
+//      });
+// const url = `${domain}/${tenantId}/${TEMPLATE_BASE_URL}/${templateId}`;
+      
+     
+//       const token = authResult.access_token;
+      
+//     const response = await fetch(url, {
+//       method: 'GET',
+//       headers: {
+//         Authorization: token,
+//         'Time-Zone': timeZone
+//       }
+//     })
+    
+//     console.log('INDEX RESPONSE', response.data)
+//     })
+    
     await app.listen({ port: PORT, host: '0.0.0.0' });
     console.log('Puppeteer Report ready with Fastify on port ', PORT);
+
   } catch (e) {
     app.log.error(e);
     logger.error(e);

--- a/server/index.js
+++ b/server/index.js
@@ -50,29 +50,6 @@ const boot = async (app) => {
       logger
     });
     
-    app.get('/:tenantId/templates/:templateId', async function (req, _res) {
-      const timeZone = req.headers['time-zone'];
-      const domain = req.headers['x-domain'] || 'https://logicawebdev2.snps.it';
-
-      const {
-        tenantId,
-        templateId
-      } = req.params;
-
-       const authResult = await auth.serviceAuth({
-        domain,
-        clientId: CLIENT_ID,
-        clientSecret: CLIENT_SECRET
-       });  
-      
-  const token = req.headers.authorization || authResult.access_token;
-
-    
-      await printer.getApiAddedStyles({ domain, templateId, tenantId, timeZone, token })
-
-      return {url, res: response.json()}
-    })
-
     app.get('/public', async (req, res) => {
       return res.sendFile('index.html');
     });
@@ -114,6 +91,8 @@ const boot = async (app) => {
 
         const token = authResult.access_token;
 
+        const printerApiStyle = await printer.getApiAddedStyles({domain, tenantId, templateId, token: token, timeZone})
+
         const printMode = getPrintMode(req.body, v1);
 
         const body = {
@@ -129,7 +108,8 @@ const boot = async (app) => {
           recordId,
           token,
           domain,
-          timeZone
+          timeZone,
+          apiCss: printerApiStyle
         });
 
         const {
@@ -151,36 +131,6 @@ const boot = async (app) => {
     app.post('/print/v2/:tenantId/:templateId/:recordId', async (req, res) => {
       await doPrintRequest(req, res, false);
     });
-    
-//     app.get('/:tenantId/templates/:templateId', async function (req, _res) {
-//     const timeZone = req.headers['time-zone'];
-//     const domain = req.headers['x-domain'] || 'logicawebdev2.snps.it';
-
-//     const {
-//       tenantId,
-//       templateId
-//     } = req.params;
-
-//      const authResult = await auth.serviceAuth({
-//       domain,
-//       clientId: CLIENT_ID,
-//       clientSecret: CLIENT_SECRET
-//      });
-// const url = `${domain}/${tenantId}/${TEMPLATE_BASE_URL}/${templateId}`;
-      
-     
-//       const token = authResult.access_token;
-      
-//     const response = await fetch(url, {
-//       method: 'GET',
-//       headers: {
-//         Authorization: token,
-//         'Time-Zone': timeZone
-//       }
-//     })
-    
-//     console.log('INDEX RESPONSE', response.data)
-//     })
     
     await app.listen({ port: PORT, host: '0.0.0.0' });
     console.log('Puppeteer Report ready with Fastify on port ', PORT);

--- a/server/index.js
+++ b/server/index.js
@@ -49,7 +49,7 @@ const boot = async (app) => {
       cluster,
       logger
     });
-    
+
     app.get('/public', async (req, res) => {
       return res.sendFile('index.html');
     });
@@ -91,7 +91,7 @@ const boot = async (app) => {
 
         const token = authResult.access_token;
 
-        const printerApiStyle = await printer.getApiAddedStyles({domain, tenantId, templateId, token: token, timeZone})
+        const printerApiStyle = await printer.getApiAddedStyles({ domain, tenantId, templateId, token: token, timeZone })
 
         const printMode = getPrintMode(req.body, v1);
 
@@ -131,7 +131,7 @@ const boot = async (app) => {
     app.post('/print/v2/:tenantId/:templateId/:recordId', async (req, res) => {
       await doPrintRequest(req, res, false);
     });
-    
+
     await app.listen({ port: PORT, host: '0.0.0.0' });
     console.log('Puppeteer Report ready with Fastify on port ', PORT);
 

--- a/server/lib/getApiTemplateCss.js
+++ b/server/lib/getApiTemplateCss.js
@@ -13,37 +13,39 @@ const factory = ({ fetch, logger }) => {
 
 const getApiTemplateCss = async function ({domain, tenantId, templateId, token, timeZone}) {
   
-  const url = `${domain}/api/v2/${tenantId}/${TEMPLATE_BASE_URL}/${templateId}`;
-
+  const url = `https://${domain}/api/v2/${tenantId}/${TEMPLATE_BASE_URL}/${templateId}`;
+  
   try { 
     const response = await fetch(url, {
-        method: 'GET',
-        headers: {
-          Authorization: token,
-          'Time-Zone': timeZone
-        }
+      method: 'GET',
+      headers: {
+        Authorization:`Bearer ${token}`,
+        'Time-Zone': timeZone
+      }
     })
+    
+    console.log('---RESPONSE---', response)
+    if (response.status !== 200) throw new Error('Richiesta completata senza successo ', response);
+    
+    const dataJson = await response.json();
 
-    if (response.status !== 200) throw new Error('Richiesta completata senza successo: stato ', response.status);
+    const customStyle = await dataJson.customStyle;
 
-    const data = await response.data.json();
+    console.log('custom style', customStyle)
 
-    const customStyle = await data.customStyle;
-
-    style = customStyle;    
+    return customStyle;  
   } catch (error) {
     logger.error(error)
+
+    return "";
   }  
   }
 
-  const getApiCssCopy = () => style;
-
   return {
-    getApiTemplateCss: ({domain, tenantId, templateId, token, timeZone}) => getApiTemplateCss({domain, tenantId, templateId, token, timeZone}),
-    getApiCssCopy
+    getApiTemplateCss,
   }
 }
 
-const service = factory({fetch, logger});
+const service = factory({ fetch, logger });
 
 module.exports = service;

--- a/server/lib/getApiTemplateCss.js
+++ b/server/lib/getApiTemplateCss.js
@@ -9,36 +9,31 @@ const factory = ({ fetch, logger }) => {
 
   const TEMPLATE_BASE_URL = 'templates';
 
-  let style = "";
+  const getApiTemplateCss = async function ({ domain, tenantId, templateId, token, timeZone }) {
 
-const getApiTemplateCss = async function ({domain, tenantId, templateId, token, timeZone}) {
-  
-  const url = `https://${domain}/api/v2/${tenantId}/${TEMPLATE_BASE_URL}/${templateId}`;
-  
-  try { 
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: {
-        Authorization:`Bearer ${token}`,
-        'Time-Zone': timeZone
-      }
-    })
-    
-    console.log('---RESPONSE---', response)
-    if (response.status !== 200) throw new Error('Richiesta completata senza successo ', response);
-    
-    const dataJson = await response.json();
+    const url = `https://${domain}/api/v2/${tenantId}/${TEMPLATE_BASE_URL}/${templateId}`;
 
-    const customStyle = await dataJson.customStyle;
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Time-Zone': timeZone
+        }
+      })
 
-    console.log('custom style', customStyle)
+      if (response.status !== 200) throw new Error('Richiesta completata senza successo ', response);
 
-    return customStyle;  
-  } catch (error) {
-    logger.error(error)
+      const dataJson = await response.json();
 
-    return "";
-  }  
+      const customStyle = await dataJson.customStyle;
+
+      return customStyle;
+    } catch (error) {
+      logger.error(error)
+
+      return "";
+    }
   }
 
   return {

--- a/server/lib/getApiTemplateCss.js
+++ b/server/lib/getApiTemplateCss.js
@@ -1,0 +1,17 @@
+  const getApiTemplateCss = async function (templateId) {
+        const url = `${apiURLs.getBasePath()}/${TEMPLATE_BASE_URL}/${templateId}`;
+
+        const response = await xdbHttpService
+          .fetch({
+            method: 'GET',
+            url: url
+          }).then(function (res) {
+            return res.data;
+          });
+        
+        return response.customStyle;
+}
+      
+module.exports = {
+    getApiTemplateCss,
+}

--- a/server/lib/getApiTemplateCss.js
+++ b/server/lib/getApiTemplateCss.js
@@ -13,7 +13,7 @@ const factory = ({ fetch, logger }) => {
 
 const getApiTemplateCss = async function ({domain, tenantId, templateId, token, timeZone}) {
   
-  const url = `${domain}/${tenantId}/${TEMPLATE_BASE_URL}/${templateId}`;
+  const url = `${domain}/api/v2/${tenantId}/${TEMPLATE_BASE_URL}/${templateId}`;
 
   try { 
     const response = await fetch(url, {
@@ -23,10 +23,10 @@ const getApiTemplateCss = async function ({domain, tenantId, templateId, token, 
           'Time-Zone': timeZone
         }
     })
-    
+
     if (response.status !== 200) throw new Error('Richiesta completata senza successo: stato ', response.status);
 
-    const data = await response.data;
+    const data = await response.data.json();
 
     const customStyle = await data.customStyle;
 

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -33,6 +33,14 @@ const applyNetworkLogging = async (page, logger) => {
 };
 
 const create = async ({ timeout, logger, networkLogging, cluster }) => {
+
+  const getApiAddedStyles = async ({ domain, tenantId, templateId, token, timeZone }) => {
+    console.log('cssApi type', typeof getCssApi)
+    console.log('cssApi value', Object.keys(getCssApi))
+    
+    await getApiCss.getApiTemplateCss({ domain, tenantId, templateId, token, timeZone })
+  }
+
   const preparePage = async ({
     token,
     page,
@@ -467,7 +475,8 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
   };
 
   return {
-    print
+    print,
+    getApiAddedStyles
   };
 };
 

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -3,6 +3,7 @@ const urlBuilder = require('./urlBuilder');
 const CCdocx = require('./cloudConvert');
 const os = require('os');
 const pathNode = require('path');
+const getApiCss = require('./getApiTemplateCss')
 
 const URL_BLACKLIST = [
   '.stripe',

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -34,12 +34,9 @@ const applyNetworkLogging = async (page, logger) => {
 };
 
 const create = async ({ timeout, logger, networkLogging, cluster }) => {
-  console.log("create getApiCss type", typeof getApiCss);
 
   const getApiAddedStyles = async ({ domain, tenantId, templateId, token, timeZone }) => {
 
-    logger.info('GET API ADDED STYLES OK')
-    
     const style = await getApiCss.getApiTemplateCss({ domain, tenantId, templateId, token, timeZone });
 
     return style;
@@ -53,8 +50,6 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
     body,
     apiCss
   }) => {
-    // console.log('PREPARE PAGE getApiCss', Object.keys(getApiCss), (() => getApiCss.getApiCssCopy())());
-    console.log('PREPARE PAGE apiCss',apiCss);
 
     await page.setDefaultNavigationTimeout(0); // disable timeout
     if (networkLogging) {
@@ -66,7 +61,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
     logger.debug(`Passing fields to the page: ${JSON.stringify(valoriCampiEditabili)}`);
 
     await page.evaluateOnNewDocument((token) => {
-      function writeCookie (name, value, options = {}) {
+      function writeCookie(name, value, options = {}) {
         if (!name) {
           return '';
         }
@@ -123,8 +118,6 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
     });
 
     const { FOOTER_TEMPLATE, HAS_FOOTER, FOOTER_H } = await page.evaluate((addedStyle) => {
-
-      console.log('---PAGE EVALUATE---', addedStyle)
 
       const SBECCO = 20;
 
@@ -217,15 +210,14 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       };
 
       const CUSTOM_CSS = getCustomCSS(HEADER_H, addedStyle);
-      
-      const newStyleTag = document.createElement("style");
-      
-        newStyleTag.innerHTML = CUSTOM_CSS;
-      document.head.appendChild(newStyleTag)
-      
-      console.log('---DOCUMENT---', `${document.head.innerHTML}`)
 
-      const getHTMLReportFromContent = function (bodyHTML, headerHTML) {  
+      const newStyleTag = document.createElement("style");
+
+      newStyleTag.innerHTML = CUSTOM_CSS;
+      document.head.appendChild(newStyleTag)
+
+      const getHTMLReportFromContent = function (bodyHTML, headerHTML) {
+        
         return `
             <div id="header" class="page-header">
               <div class="standard-padding">${headerHTML}</div>
@@ -303,7 +295,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
     const IS_LANDSCAPE = WIDTH > HEIGHT;
 
     const PAGE_CSS = `@page { size: ${WIDTH} ${HEIGHT} ${(IS_LANDSCAPE ? 'landscape' : '')}; } ${apiCss}`;
-    
+
     await page.addStyleTag(
       { content: PAGE_CSS }
     );
@@ -311,8 +303,6 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
     const {
       printMode
     } = body;
-
-    console.log(Date.now());
 
     const config = {
       preferCSSPageSize: true,
@@ -385,8 +375,6 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
     body,
     apiCss
   }) => {
-    console.log('PROCESS PAGE apiCss', apiCss)
-    // console.log('PROCESS PAGE getApiCss', Object.keys(getApiCss), getApiCss.getApiCssCopy())
 
     return Promise.race([
       preparePage({
@@ -434,10 +422,6 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       apiCss
     }
   }) => {
-
-    console.log('GET API CSS CLUSTER TASK', apiCss)
-    // console.log('GET API CSS CLUSTER TASK', Object.keys(getApiCss), getApiCss.getApiCssCopy())
-
     const start = Date.now();
     const {
       printMode
@@ -489,8 +473,6 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
     v2,
     apiCss
   }) => {
-    // console.log("print getApiCss type", Object.keys(getApiCss), getApiCss.getApiCssCopy());
-    console.log("print apiCss type", apiCss);
 
     return await cluster.execute({
       port,

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -34,12 +34,15 @@ const applyNetworkLogging = async (page, logger) => {
 };
 
 const create = async ({ timeout, logger, networkLogging, cluster }) => {
+  console.log("create getApiCss type", typeof getApiCss);
 
   const getApiAddedStyles = async ({ domain, tenantId, templateId, token, timeZone }) => {
-    console.log('cssApi type', typeof getCssApi)
-    console.log('cssApi value', Object.keys(getCssApi))
+
+    logger.info('GET API ADDED STYLES OK')
     
-    await getApiCss.getApiTemplateCss({ domain, tenantId, templateId, token, timeZone })
+    const style = await getApiCss.getApiTemplateCss({ domain, tenantId, templateId, token, timeZone });
+
+    return style;
   }
 
   const preparePage = async ({
@@ -47,8 +50,12 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
     page,
     url,
     timeZone,
-    body
+    body,
+    apiCss
   }) => {
+    // console.log('PREPARE PAGE getApiCss', Object.keys(getApiCss), (() => getApiCss.getApiCssCopy())());
+    console.log('PREPARE PAGE apiCss',apiCss);
+
     await page.setDefaultNavigationTimeout(0); // disable timeout
     if (networkLogging) {
       await applyNetworkLogging(page, logger);
@@ -200,7 +207,6 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
             orphans: 0;
             widows: 4;
           }
-  
           `;
         return CUSTOM_CSS;
       };
@@ -287,8 +293,10 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
 
     const IS_LANDSCAPE = WIDTH > HEIGHT;
 
-    const PAGE_CSS = `@page { size: ${WIDTH} ${HEIGHT} ${(IS_LANDSCAPE ? 'landscape' : '')}; }`;
-
+    // const apiAddedStyles = (() => getApiCss.getApiCssCopy())();
+    const PAGE_CSS = `@page { size: ${WIDTH} ${HEIGHT} ${(IS_LANDSCAPE ? 'landscape' : '')}; } ${apiCss}`;
+    
+    console.log('PREPARE PAGE apiAddedStyles', PAGE_CSS);
     await page.addStyleTag(
       { content: PAGE_CSS }
     );
@@ -367,15 +375,20 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
     page,
     url,
     timeZone,
-    body
+    body,
+    apiCss
   }) => {
+    console.log('PROCESS PAGE apiCss', apiCss)
+    // console.log('PROCESS PAGE getApiCss', Object.keys(getApiCss), getApiCss.getApiCssCopy())
+
     return Promise.race([
       preparePage({
         token,
         page,
         url,
         timeZone,
-        body
+        body,
+        apiCss
       }),
       timeoutUtils.resolve(timeout, page).then(() => {
         throw new Error('timeout');
@@ -410,9 +423,14 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       token,
       timeZone,
       body,
-      domain
+      domain,
+      apiCss
     }
   }) => {
+
+    console.log('GET API CSS CLUSTER TASK', apiCss)
+    // console.log('GET API CSS CLUSTER TASK', Object.keys(getApiCss), getApiCss.getApiCssCopy())
+
     const start = Date.now();
     const {
       printMode
@@ -436,7 +454,8 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       page,
       url,
       timeZone,
-      body
+      body,
+      apiCss
     });
 
     const buffer = await generator(page, config);
@@ -460,8 +479,12 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
     timeZone,
     body,
     domain,
-    v2
+    v2,
+    apiCss
   }) => {
+    // console.log("print getApiCss type", Object.keys(getApiCss), getApiCss.getApiCssCopy());
+    console.log("print apiCss type", apiCss);
+
     return await cluster.execute({
       port,
       templateId,
@@ -471,7 +494,8 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       timeZone,
       body,
       domain,
-      v2
+      v2,
+      apiCss
     });
   };
 

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -274,6 +274,12 @@
               });
             });
 
+             reportService.getApiTemplateCss(parseInt(searchParams.get('idTemplate'), 10)).then((res) => { 
+            const styleTag = document.createElement("style");
+            styleTag.textContent = `${res}`;
+            document.head.appendChild(styleTag)
+          })
+
             return campiEditabiliReport.applyValues(valoriCampiEditabili).then(() => {
               const images = body.querySelectorAll('[data-avatar-record]');
 
@@ -293,6 +299,7 @@
                   });
               });
             });
+            
           }).catch(function (e) {
             printError(e);
           }).finally(function () {
@@ -312,6 +319,7 @@
               }
             });
           });
+          
         } catch (error) {
           printError(error);
         }

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -274,11 +274,11 @@
               });
             });
 
-             reportService.getApiTemplateCss(parseInt(searchParams.get('idTemplate'), 10)).then((res) => { 
-            const styleTag = document.createElement("style");
-            styleTag.textContent = `${res}`;
-            document.head.appendChild(styleTag)
-          })
+            reportService.getApiTemplateCss(parseInt(searchParams.get('idTemplate'), 10)).then((res) => {
+              const styleTag = document.createElement("style");
+              styleTag.textContent = `${res}`;
+              document.head.appendChild(styleTag)
+            })
 
             return campiEditabiliReport.applyValues(valoriCampiEditabili).then(() => {
               const images = body.querySelectorAll('[data-avatar-record]');
@@ -299,7 +299,7 @@
                   });
               });
             });
-            
+
           }).catch(function (e) {
             printError(e);
           }).finally(function () {
@@ -319,7 +319,7 @@
               }
             });
           });
-          
+
         } catch (error) {
           printError(error);
         }

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -58,12 +58,6 @@
 
     <!-- App JS -->
     <script src="./app.js"></script>
-</head>
-
-<body ng-controller="myController">
-    <div ng-show="!loading && !error">
-        <div class="report-wrapper"></div>
-    </div>
 
     <style>
         .report-wrapper {
@@ -94,6 +88,12 @@
             white-space: pre-line;
         }
     </style>
+</head>
+
+<body ng-controller="myController">
+    <div ng-show="!loading && !error">
+        <div class="report-wrapper"></div>
+    </div>
 
     <div ng-if="loading" class="p-4">
         <p class="text-center" style="font-size: 30px;">Generazione report in corso...</p>

--- a/server/public/modules/report/service/reportService.js
+++ b/server/public/modules/report/service/reportService.js
@@ -40,9 +40,9 @@
             url: url
           })
         
-        const dataJson = await JSON.parse(response); 
+        const customStyle = await response?.data?.customStyle || ""; 
         
-        return dataJson?.customStyle || "";
+        return customStyle;
       }
 
       const getVisteTemplate = function (id) {

--- a/server/public/modules/report/service/reportService.js
+++ b/server/public/modules/report/service/reportService.js
@@ -38,11 +38,11 @@
           .fetch({
             method: 'GET',
             url: url
-          }).then(function (res) {
-            return res.data;
-          });
+          })
         
-        return response.customStyle;
+        const dataJson = await JSON.parse(response); 
+        
+        return dataJson?.customStyle || "";
       }
 
       const getVisteTemplate = function (id) {

--- a/server/public/modules/report/service/reportService.js
+++ b/server/public/modules/report/service/reportService.js
@@ -31,6 +31,20 @@
           });
       };
 
+      const getApiTemplateCss = async function (templateId) {
+        const url = `${apiURLs.getBasePath()}/${TEMPLATE_BASE_URL}/${templateId}`;
+
+        const response = await xdbHttpService
+          .fetch({
+            method: 'GET',
+            url: url
+          }).then(function (res) {
+            return res.data;
+          });
+        
+        return response.customStyle;
+      }
+
       const getVisteTemplate = function (id) {
         const url = `${apiURLs.getBasePath()}/${TEMPLATE_BASE_URL}/${id}/viste`;
         return xdbHttpService
@@ -61,7 +75,8 @@
         getInfoBase,
         getTemplate,
         getVisteTemplate,
-        getDatiSchedaDiRiferimento
+        getDatiSchedaDiRiferimento,
+        getApiTemplateCss
       };
     }
   ]);


### PR DESCRIPTION
## Esigenza del feat:
Quando si crea un report al momento non è possibile aggiungere degli stili CSS se non in-line.

Bisognerebbe fare in modo che sia possibile aggiungere degli stili CSS (tramite il tag <style>)

---

## Cosa comprende questa pr:

- Nuova funzione in `reportService.js` per ottenere gli stili rilevanti nella risposta proveniente da `/api/v2/:tenantId/templates/:templateId`
- Iniettati gli stili nel tag `<style>` nell'`<head>` del template in `index.html` da `app.js` per poter visualizzare gli stili nell'anteprima inviata al client
- Creato nuovo service in ambiente Node.js per gestire la chiamata api sopracitata e restituirne la parte di risposta rilevante: `getApiTemplateCss.js`
- Inserito `getApiTemplateCss()` nel flusso della gestione dell'operazione di invio stampa: utilizza le variabili all'interno di `doPrintRequest()` in `service/index.js`, ne viene passato il risultato come proprietà alla funzione `printer.print()` che allo stesso modo trasferisce la proprietà alle varie funzioni annidate fino ad arrivare a `getCustomCSS()` dove viene effettivamente usato

N.B.: per quanto riguarda lo stile proveniente da api, vivendo nel tag `<style>` in `document.head`, sarà comunque sovrascritto da stile inline se presente