### PR TITLE
fix: reports: ripristino ripetizione header e contenuto in interruzione pagine (Rif. Int. 2025/ 4393) 

### DIFF
--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -208,18 +208,13 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
           `;
         return CUSTOM_CSS;
       };
-
+            
       const CUSTOM_CSS = getCustomCSS(HEADER_H, addedStyle);
-
-      const newStyleTag = document.createElement("style");
-
-      newStyleTag.innerHTML = CUSTOM_CSS;
-      const currentStyle = document.head.style;
-      currentStyle.textContent = CUSTOM_CSS;
 
       const getHTMLReportFromContent = function (bodyHTML, headerHTML) {
         
         return `
+        <style>${CUSTOM_CSS}</style>
             <div id="header" class="page-header">
               <div class="standard-padding">${headerHTML}</div>
             </div>

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -138,7 +138,7 @@
           if (error && error.message) {
             return error.message;
           }
-          return 'Errore sconosciuto';
+          return `Errore sconosciuto: ${error.textContent}`;
         };
 
         const printError = e => {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -275,9 +275,21 @@
             });
 
             reportService.getApiTemplateCss(parseInt(searchParams.get('idTemplate'), 10)).then((res) => {
-              const styleTag = document.createElement("style");
-              styleTag.textContent = `${res}`;
-              document.head.appendChild(styleTag)
+              const withPrintInstructions = res.length > 0 ? `@media print {
+             ${res} 
+            }` : '';
+              
+              const styleTags = document.querySelectorAll("style");
+              const styleTag = styleTags[styleTags.length - 1];
+
+              if (!styleTag) {
+                const newStyleTag = document.createElement('style');
+                newStyleTag.textContent = res;
+                document.head.appendChild(newStyleTag)
+              } else {
+                styleTag.textContent = `${styleTag.textContent}\n${res}\n${withPrintInstructions}`;
+              }
+
             })
 
             return campiEditabiliReport.applyValues(valoriCampiEditabili).then(() => {

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -58,8 +58,10 @@
 
     <!-- App JS -->
     <script src="./app.js"></script>
+</head>
 
-    <style>
+<body ng-controller="myController">
+     <style>
         .report-wrapper {
             position: absolute;
             top: 0;
@@ -88,9 +90,7 @@
             white-space: pre-line;
         }
     </style>
-</head>
-
-<body ng-controller="myController">
+    
     <div ng-show="!loading && !error">
         <div class="report-wrapper"></div>
     </div>


### PR DESCRIPTION
## Esigenza del fix:
Nella generazione del Preventivo,
l'intestazione esce solo nella 1 pagina, nelle successive dalla pag 2 , l'intestazione non viene inserita e di conseguenza il testo viene inserito dall'inizio pagina..
Riferimento: Preventivo nr 2025/7835 del 28/10/2025
Report: Preventivo Int-157537

ID record: 157537
ID Report -268

In più: le righe di tabelle vengono troncate tra due pagine, il comportamento attesso è vedere l’intera riga di tabella nella pagina successiva.

---

##  Cosa comprende questa pr:
- ripristino delle posizioni dei tag style alla loro posizione precedente al commit 41df439790e743d878fc43a8df30591038956d90 . **Per reference futura:** i frammenti di template nei files printer.js e index.html necessitano di caricare gli stili nell'ordine di specificità in cui sono stati posti.
- modificata aggiunta dello stile proveniente da client. 
  In `app.js`: innesto dello stile nell'ultimo tag style esistente nel document; se non ne esistono, crea un nuovo tag style da inserire nel `document.head`.
  In `printer.js`: lo stile proveniente da client viene aggiunto solo all'interno della risposta di `getCustomCSS()` e non ripetuto in altri tags style. 
- migliorata la gestione dell'errore in `getApiTemplateCss.js`
- reso più esplicito il messaggio di errore restituito da `getErrorMessage()` in `app.js`.