### PR TITLE
Feat: gestione id record multipli in anteprima stampa e stampa report(Rif.Int.: 2025/ 4394)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -158,10 +158,6 @@ const boot = async (app) => {
       await doPrintRequest(req, res, false);
     });
 
-    app.post('/print/v2/:tenantId/:templateId/%IN=:recordId', async (req, res) => {
-      await doPrintRequest(req, res, false);
-    });
-
     await app.listen({ port: PORT, host: '0.0.0.0' });
     console.log('Puppeteer Report ready with Fastify on port ', PORT);
 

--- a/server/index.js
+++ b/server/index.js
@@ -132,6 +132,10 @@ const boot = async (app) => {
       await doPrintRequest(req, res, false);
     });
 
+    app.post('/print/v2/:tenantId/:templateId/%IN=:recordId', async (req, res) => {
+      await doPrintRequest(req, res, false);
+    });
+
     await app.listen({ port: PORT, host: '0.0.0.0' });
     console.log('Puppeteer Report ready with Fastify on port ', PORT);
 

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -408,9 +408,8 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
   cluster.task(async ({
     page, data: {
       port,
-      templateId,
-      recordId,
-      tenantId,
+      path,
+      queryParams,
       token,
       timeZone,
       body,
@@ -429,9 +428,8 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
     const url = urlBuilder({
       port,
       domain,
-      tenantId,
-      templateId,
-      recordId
+      path,
+      queryParams
     });
 
     logger.info(`Opening ${url}`);
@@ -459,9 +457,8 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
 
   const print = async ({
     port,
-    templateId,
-    recordId,
-    tenantId,
+    path,
+    queryParams,
     token,
     timeZone,
     body,
@@ -472,9 +469,8 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
 
     return await cluster.execute({
       port,
-      templateId,
-      recordId,
-      tenantId,
+      path,
+      queryParams,
       token,
       timeZone,
       body,

--- a/server/lib/urlBuilder.js
+++ b/server/lib/urlBuilder.js
@@ -1,16 +1,3 @@
-const buildRecordIdsUrl = function (builderParams) {
-  const { port, domain, tenantId, templateId, recordId } = builderParams;
-
-  const isRecordIdAList = () => [...recordId.matchAll(/((?=.*[0-9])(?=.*,).*$)/g)].length > 0;
-
-  if (!isRecordIdAList()) return null;
-  
-  const encodedDomain = encodeURIComponent(`https://${domain}`);
-  const encodedIdsInclusionParam = encodeURIComponent(`%IN=${recordId}`);
-
-  return `http://localhost:${port}/print/public/index.html?idTemplate=${templateId}&idRecord=${encodedIdsInclusionParam}&tenantId=${tenantId}&domain=${encodedDomain}`; 
-};
-
 const build = ({
   port,
   domain,

--- a/server/lib/urlBuilder.js
+++ b/server/lib/urlBuilder.js
@@ -1,3 +1,16 @@
+const buildRecordIdsUrl = function (builderParams) {
+  const { port, domain, tenantId, templateId, recordId } = builderParams;
+
+  const isRecordIdAList = () => [...recordId.matchAll(/((?=.*[0-9])(?=.*,).*$)/g)].length > 0;
+
+  if (!isRecordIdAList()) return null;
+  
+  const encodedDomain = encodeURIComponent(`https://${domain}`);
+  const encodedIdsInclusionParam = encodeURIComponent(`%IN=${recordId}`);
+
+  return `http://localhost:${port}/print/public/index.html?idTemplate=${templateId}&idRecord=${encodedIdsInclusionParam}&tenantId=${tenantId}&domain=${encodedDomain}`; 
+};
+
 const build = ({
   port,
   domain,
@@ -5,6 +18,11 @@ const build = ({
   templateId,
   recordId
 }) => {
+
+  const recordIdsUrl = buildRecordIdsUrl({ port, domain, tenantId, templateId, recordId });
+  
+  if (typeof recordIdsUrl === "string") return recordIdsUrl;
+
   const _domain = `https://${domain}`;
   return `http://localhost:${port}/print/public/index.html?idTemplate=${templateId}&idRecord=${recordId}&tenantId=${tenantId}&domain=${encodeURIComponent(_domain)}`;
 };

--- a/server/lib/urlBuilder.js
+++ b/server/lib/urlBuilder.js
@@ -14,17 +14,16 @@ const buildRecordIdsUrl = function (builderParams) {
 const build = ({
   port,
   domain,
-  tenantId,
-  templateId,
-  recordId
+  path,
+  queryParams
 }) => {
-
-  const recordIdsUrl = buildRecordIdsUrl({ port, domain, tenantId, templateId, recordId });
   
-  if (typeof recordIdsUrl === "string") return recordIdsUrl;
-
+  const idRecord = path?.recordId ?? queryParams?.idRecord;
+  
+  if (!idRecord) throw new Error('recordId non è presente né nel path né come parametro di ricerca.');
+ 
   const _domain = `https://${domain}`;
-  return `http://localhost:${port}/print/public/index.html?idTemplate=${templateId}&idRecord=${recordId}&tenantId=${tenantId}&domain=${encodeURIComponent(_domain)}`;
+  return `http://localhost:${port}/print/public/index.html?idTemplate=${path.templateId}${typeof idRecord !== 'string' ? '' : `&idRecord=${idRecord}`}&tenantId=${path.tenantId}&domain=${encodeURIComponent(_domain)}`;
 };
 
 module.exports = build;

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -199,10 +199,22 @@
               promises.push(xdbApiService.getValoriCampiScheda(idScheda, idRecord));
             }
 
+            const validateIdRecordParam = (idRecord) => {
+              if (!idRecord) {
+                throw new Error('idRecord mancante');
+              };
+
+              if(idRecord.includes('%25')) {
+                return `=${idRecord}`;
+              }
+
+              return `=%25=${idRecord}`;
+            }
+
             idViste.forEach(function (idVista) {
               const vistaCorrelata = visteCorrelate.find(function (v) { return v.idVista === idVista; }) || {};
               const foreignKeyVista = vistaCorrelata.campoVistaPerFiltro;
-              const q = foreignKeyVista ? (foreignKeyVista + '=%25=' + idRecord) : null;
+              const q = foreignKeyVista ? `${foreignKeyVista}${validateIdRecordParam(idRecord)}` : null;
               const limit = q ? -1 : 1000;
               promises.push(xdbApiService.getVistaRows(idVista, limit, 0, null, q));
             });
@@ -278,7 +290,7 @@
               const withPrintInstructions = res.length > 0 ? `@media print {
              ${res} 
             }` : '';
-              
+
               const styleTags = document.querySelectorAll("style");
               const styleTag = styleTags[styleTags.length - 1];
 

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -138,7 +138,7 @@
           if (error && error.message) {
             return error.message;
           }
-          return `Errore sconosciuto: ${error.textContent}`;
+          return `Errore sconosciuto: ${error.jsonValue()}`;
         };
 
         const printError = e => {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -152,9 +152,10 @@
 
         try {
           const url = new URL(window.location.href);
+          // console.log('url,', url.toString())
           const searchParams = url.searchParams;
           const idTemplate = parseInt(searchParams.get('idTemplate'), 10);
-          const idRecord = parseInt(searchParams.get('idRecord'), 10);
+          const idRecord = searchParams.get('idRecord');
           const tenantId = parseInt(searchParams.get('tenantId'), 10);
 
           currentUser.changeTenant(tenantId);
@@ -201,10 +202,10 @@
 
             const validateIdRecordParam = (idRecord) => {
               if (!idRecord) {
-                throw new Error('idRecord mancante');
+                throw new Error('idRecord mancante', idRecord);
               };
 
-              if(idRecord.includes('%25')) {
+              if(!idRecord.includes('%25')) {
                 return `=${idRecord}`;
               }
 
@@ -212,9 +213,11 @@
             }
 
             idViste.forEach(function (idVista) {
+              // console.log('idVista', idVista)
               const vistaCorrelata = visteCorrelate.find(function (v) { return v.idVista === idVista; }) || {};
               const foreignKeyVista = vistaCorrelata.campoVistaPerFiltro;
               const q = foreignKeyVista ? `${foreignKeyVista}${validateIdRecordParam(idRecord)}` : null;
+              // console.log('idViste.forEach q', q)
               const limit = q ? -1 : 1000;
               promises.push(xdbApiService.getVistaRows(idVista, limit, 0, null, q));
             });

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -344,7 +344,7 @@
                 
               }
 
-              reportService.getApiTemplateCss(parseInt(searchParams.get('idTemplate'), 10)).then((res) => {
+              reportService.getApiTemplateCss(idTemplate).then((res) => {
                 const withPrintInstructions = res.length > 0 ? `@media print {
              ${res} 
             }` : '';

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -304,47 +304,6 @@
                 });
               });
 
-              if ($scope.infoBase?.idRecords?.length > 0 && !$scope.infoBase?.idRecord) {
-                
-                (async () => await domUtilsService.waitForSelector('[data-infobase-idrecords]').then((_tableContainer) => {
-                  const tableContainersList = body.querySelectorAll('[data-infobase-idrecords]'); 
-                  
-                  if (!tableContainersList?.length) throw new Error('Lista di contenitori delle tabelle per idRecords vuota');
-                  
-                  tableContainersList.forEach((divContainer, index) => {
-                    const spanToSubstitute = body.querySelector(`[data-idrecords-table-space="${$scope.infoBase.idRecords[index]}"]`);
-
-                    if (!spanToSubstitute) throw new Error('Elemento da sostituire non trovato');
-
-                    manageSchedeIdRecords.buildTableFromSchedaObj($scope.infoBase.idRecords[index], parseInt(searchParams.get('idTemplate'), 10)).then((res) => res).then((resHtml) => {
-
-                      return spanToSubstitute.replaceWith(resHtml);
-
-                    }).catch(error => new Error("Non ci sono elementi html validi per creare una tabella \n", error.message));
-
-                  })                 
-
-              }).catch((error) => {
-                console.error(error?.message ?? error?.jsonValue());
-              }))()
-
-            } else if (!$scope.infoBase?.idRecords?.length && $scope.infoBase?.idRecord) {
-
-                (async () => await domUtilsService.waitForSelector('[data-infobase-idrecord]').then((tableContainer) => {
-                  const divContainer = body.querySelectorAll(`[data-infobase-idrecord="${$scope.infoBase.idRecord}"]`); 
-
-                  const spanToSubstitute = body.querySelector(`[data-idrecord-table-space="${$scope.infoBase.idRecord}"]`);
-
-                  if (!spanToSubstitute) throw new Error('Elemento da sostituire non trovato');
-                  
-                  const table = manageSchedeIdRecords.getTableFromSchedaObj($scope, $scope.infoBase.idRecord);
-
-                  divContainer.replaceChild(table, spanToSubstitute);
-                  
-                }).catch((_error) => { }))();
-                
-              }
-
               reportService.getApiTemplateCss(parseInt(searchParams.get('idTemplate'), 10)).then((res) => {
                 const withPrintInstructions = res.length > 0 ? `@media print {
              ${res} 

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -248,8 +248,21 @@
             }
           }).then(function (res) {
             if (res && idScheda) {
-              const resScheda = res.splice(0, 1);
-              Object.assign($scope, reportHelpers.mapSchedaToReportData(infoScheda, resScheda[0].data));
+              const assignResultsToScope = (res) => {
+                if (!Array.isArray(idRecord)) {
+                  const resScheda = res.splice(0, 1);
+
+                  return Object.assign($scope, reportHelpers.mapSchedaToReportData(infoScheda, resScheda[0].data));
+                }
+
+                const resScheda = res.splice(0, idRecord.length);
+
+                return resScheda.forEach((record) => {
+                  Object.assign($scope, reportHelpers.mapSchedaToReportData(infoScheda, record.data));
+                })
+              };
+              
+              assignResultsToScope(res);
             }
 
             if (res && res.length) {

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -298,6 +298,42 @@
                 });
               });
 
+              if ($scope.infoBase?.idRecords?.length > 0 && !$scope.infoBase?.idRecord) {
+                
+                (async () => await domUtilsService.waitForSelector('[data-infobase-idrecords]').then((_tableContainer) => {
+                  const tableContainersList = body.querySelectorAll('[data-infobase-idrecords]'); 
+                  
+                  if (!tableContainersList?.length) throw new Error('Lista di contenitori delle tabelle per idRecords vuota');
+                  
+                  tableContainersList.forEach((divContainer, index) => {
+                    const spanToSubstitute = body.querySelector(`[data-idrecords-table-space]="${$scope.infoBase.idRecords[index]}"`);
+
+                    if (!spanToSubstitute) throw new Error('Elemento da sostituire non trovato');
+
+                    const table = manageSchedeIdRecords.getTableFromSchedaObj($scope, $scope.infoBase.idRecords[index]);
+
+                    divContainer.replaceChild(table, spanToSubstitute);
+                  })                 
+
+                }).catch((_error) => { }))()
+                
+              } else if (!$scope.infoBase?.idRecords?.length && $scope.infoBase?.idRecord) {
+
+                (async () => await domUtilsService.waitForSelector('[data-infobase-idrecord]').then((tableContainer) => {
+                  const divContainer = body.querySelectorAll('[data-infobase-idrecord]="$scope.infoBase.idRecord"'); 
+
+                  const spanToSubstitute = body.querySelector(`[data-idrecord-table-space]="${$scope.infoBase.idRecord}"`);
+
+                  if (!spanToSubstitute) throw new Error('Elemento da sostituire non trovato');
+                  
+                  const table = manageSchedeIdRecords.getTableFromSchedaObj($scope, $scope.infoBase.idRecord);
+
+                  divContainer.replaceChild(table, spanToSubstitute);
+                  
+                }).catch((_error) => { }))();
+                
+              }
+
               reportService.getApiTemplateCss(parseInt(searchParams.get('idTemplate'), 10)).then((res) => {
                 const withPrintInstructions = res.length > 0 ? `@media print {
              ${res} 

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -140,7 +140,7 @@
           if (error && error.message) {
             return error.message;
           }
-          return `Errore sconosciuto: ${error.jsonValue()}`;
+          return `Errore sconosciuto: ${typeof error} ${error}`;
         };
 
         const printError = e => {
@@ -312,13 +312,16 @@
                   if (!tableContainersList?.length) throw new Error('Lista di contenitori delle tabelle per idRecords vuota');
                   
                   tableContainersList.forEach((divContainer, index) => {
-                    const spanToSubstitute = body.querySelector(`[data-idrecords-table-space]="${$scope.infoBase.idRecords[index]}"`);
+                    const spanToSubstitute = body.querySelector(`[data-idrecords-table-space="${$scope.infoBase.idRecords[index]}"]`);
 
                     if (!spanToSubstitute) throw new Error('Elemento da sostituire non trovato');
 
-                  const table = manageSchedeIdRecords.buildTableFromSchedaObj($scope.infoBase.idRecords[index], idTemplate);
+                    manageSchedeIdRecords.buildTableFromSchedaObj($scope.infoBase.idRecords[index], parseInt(searchParams.get('idTemplate'), 10)).then((res) => res).then((resHtml) => {
 
-                    divContainer.replaceChild(table, spanToSubstitute);
+                      return spanToSubstitute.replaceWith(resHtml);
+
+                    }).catch(error => new Error("Non ci sono elementi html validi per creare una tabella \n", error.message));
+
                   })                 
 
               }).catch((error) => {
@@ -328,9 +331,9 @@
             } else if (!$scope.infoBase?.idRecords?.length && $scope.infoBase?.idRecord) {
 
                 (async () => await domUtilsService.waitForSelector('[data-infobase-idrecord]').then((tableContainer) => {
-                  const divContainer = body.querySelectorAll('[data-infobase-idrecord]="$scope.infoBase.idRecord"'); 
+                  const divContainer = body.querySelectorAll(`[data-infobase-idrecord="${$scope.infoBase.idRecord}"]`); 
 
-                  const spanToSubstitute = body.querySelector(`[data-idrecord-table-space]="${$scope.infoBase.idRecord}"`);
+                  const spanToSubstitute = body.querySelector(`[data-idrecord-table-space="${$scope.infoBase.idRecord}"]`);
 
                   if (!spanToSubstitute) throw new Error('Elemento da sostituire non trovato');
                   
@@ -342,7 +345,7 @@
                 
               }
 
-              reportService.getApiTemplateCss(idTemplate).then((res) => {
+              reportService.getApiTemplateCss(parseInt(searchParams.get('idTemplate'), 10)).then((res) => {
                 const withPrintInstructions = res.length > 0 ? `@media print {
              ${res} 
             }` : '';

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -170,6 +170,18 @@
           return asNumsArray;
         }
 
+        const validateIdRecordParam = (idRecord) => {
+              if (!idRecord) {
+                throw new Error('idRecord mancante', idRecord);
+              };
+
+              if(Array.isArray(idRecord)) {
+                return `=%25IN=${idRecord.toString()}`;
+              }
+
+              return `=%25=${idRecord}`;
+            }
+
         try {
           const url = new URL(window.location.href);
           const searchParams = url.searchParams;
@@ -203,8 +215,13 @@
             Object.assign($scope, {
               infoBase
             });
-            $scope.infoBase.idRecord = idRecord;
 
+            Object.assign($scope.infoBase, Array.isArray(idRecord) ? {
+              idRecords: idRecord,
+            } : {
+              idRecord
+            });
+            
             idScheda = reportHelpers.getIdScheda(template);
             idViste = reportHelpers.getIdViste(template);
 
@@ -221,18 +238,6 @@
               })
             } else if (idScheda && !Array.isArray(idRecord)) {
               promises.push(xdbApiService.getValoriCampiScheda(idScheda, idRecord));
-            }
- 
-            const validateIdRecordParam = (idRecord) => {
-              if (!idRecord) {
-                throw new Error('idRecord mancante', idRecord);
-              };
-
-              if(Array.isArray(idRecord)) {
-                return `=%25IN=${idRecord.toString()}`;
-              }
-
-              return `=%25=${idRecord}`;
             }
 
             idViste.forEach(function (idVista) {
@@ -308,7 +313,7 @@
               const filtroPerCampo = primaFoto.dataset.filtro;
 
               // genere la query per andare a recuperare i dati per una persona specifica
-              const q = filtroPerCampo ? (filtroPerCampo + '=%25=' + idRecord) : null;
+              const q = filtroPerCampo ? `${filtroPerCampo}${validateIdRecordParam(idRecord)}` : null;
               xdbApiService.getVistaRows(idVista, 1, 0, null, q).then((res) => {
                 const records = res.data.records ?? [];
                 const image = records.filter(file => filesPerCampo.isImage(file.nome));

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -316,9 +316,7 @@
 
                     if (!spanToSubstitute) throw new Error('Elemento da sostituire non trovato');
 
-                  const schedaObj = getCampiSchedaObject(res, idRecord);
-
-                  const table = manageSchedeIdRecords.buildTableFromSchedaObj(schedaObj);
+                  const table = manageSchedeIdRecords.buildTableFromSchedaObj($scope.infoBase.idRecords[index], idTemplate);
 
                     divContainer.replaceChild(table, spanToSubstitute);
                   })                 

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -46,7 +46,8 @@
 
     <script src="./modules/report/service/campiEditabiliReport.js"></script>
     <script src="./modules/report/service/reportService.js"></script>
-    <script src="./modules/report/service/manageSchedeIdRecords.js"></script>
+    <script src="./modules/report/service/reportHelpers.js"></script>
+    <script src="./modules/report/service/handleIdRecordsParams.js"></script>
 
     <script src="./modules/report/directives/attachFiles.js"></script>
     <script src="./modules/report/directives/attachGalleriaReport.js"></script>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -46,6 +46,7 @@
 
     <script src="./modules/report/service/campiEditabiliReport.js"></script>
     <script src="./modules/report/service/reportService.js"></script>
+    <script src="./modules/report/service/manageSchedeIdRecords.js"></script>
 
     <script src="./modules/report/directives/attachFiles.js"></script>
     <script src="./modules/report/directives/attachGalleriaReport.js"></script>

--- a/server/public/modules/report/service/handleIdRecordsParams.js
+++ b/server/public/modules/report/service/handleIdRecordsParams.js
@@ -1,7 +1,7 @@
 (function () {
   const service = function () {
 
-    const canParamBecomeArray = (param) => [...param.matchAll(/^(?=.*%)(?=.*\bIN\b)(?=.*=)(?=.*,).*$/g)]?.length > 0;
+    const canParamBecomeArray = (param) => [...param.matchAll(/((?=.*[0-9])(?=.*,).*$)/g)]?.length > 0;
 
     this.getArrayIdRecords = (searchParams) => {
       if (!searchParams) throw new Error("SearchParams assenti");

--- a/server/public/modules/report/service/handleIdRecordsParams.js
+++ b/server/public/modules/report/service/handleIdRecordsParams.js
@@ -1,0 +1,75 @@
+(function () {
+  const service = function () {
+
+    const canParamBecomeArray = (param) => [...param.matchAll(/^(?=.*%)(?=.*\bIN\b)(?=.*=)(?=.*,).*$/g)]?.length > 0;
+
+    this.getArrayIdRecords = (searchParams) => {
+      if (!searchParams) throw new Error("SearchParams assenti");
+
+      const idRecordParam = searchParams.get('idRecord');
+
+      if (!idRecordParam) throw new Error("Parametro idRecord assente");
+
+      if (!canParamBecomeArray(idRecordParam)) return [];
+
+      const withoutInclusion = idRecordParam.split(/(%25|IN|=|%3D|,|%)/).filter((subStr) => typeof subStr === 'string' && !subStr.match(/(%25|IN|=|%3D|,|%)/));
+      const asStringsArray = withoutInclusion.filter(str => typeof str === 'string' && str.match(/[0-9]/));
+      const asNumsArray = asStringsArray.map(str => parseInt(str, 10));
+
+      return asNumsArray;
+    };
+
+    this.getIntIdRecord = (searchParams) => {
+      if (!searchParams) throw new Error("SearchParams assenti");
+
+      const idRecordParam = searchParams.get('idRecord');
+
+      if (!idRecordParam) throw new Error("Parametro idRecord assente");
+
+      if (canParamBecomeArray(idRecordParam)) {
+        const array = this.getArrayIdRecords(searchParams);
+
+        return array[0];
+      }
+      
+      return parseInt(idRecordParam, 10);
+    };
+
+    this.validateIdRecordParam = (idRecord) => {
+      if (!idRecord) {
+        throw new Error('idRecord mancante', typeof idRecord);
+      };
+
+      if (Array.isArray(idRecord)) {
+        return `=%25IN=${idRecord.toString()}`;
+      }
+
+      return `=%25=${idRecord}`;
+    };
+
+    this.makeVistaRowsQueryParams = (queryKey, idRecord) => {
+      if (!idRecord) {
+        throw new Error('idRecord mancante', typeof idRecord);
+      };
+
+      if (!queryKey) {
+        throw new Error('queryKey mancante', typeof queryKey);
+      };
+
+      if (!queryKey) return null;
+
+      if (!Array.isArray(idRecord)) {
+        return `${queryKey}${this.validateIdRecordParam(idRecord)}`;
+      }
+
+      return idRecord.map((idR) => `${queryKey}${this.validateIdRecordParam(idR)}`)
+     };
+
+  };
+
+  window.angular
+    .module('reportApp.report')
+    .service('handleIdRecordsParams', [
+      service
+    ]);
+})();

--- a/server/public/modules/report/service/manageSchedeIdRecords.js
+++ b/server/public/modules/report/service/manageSchedeIdRecords.js
@@ -1,87 +1,119 @@
 (function () {
-    const service = function () {
-        this.getValidIdRecord = (searchParams) => {
-            if (!searchParams) throw new Error("SearchParams assenti");
+  const service = function (xdbApiService, reportService) {
+    this.getValidIdRecord = (searchParams) => {
+      if (!searchParams) throw new Error("SearchParams assenti");
 
-            const idRecordParam = searchParams.get('idRecord');
+      const idRecordParam = searchParams.get('idRecord');
 
-            if (!idRecordParam) throw new Error("Parametro idRecord assente");
+      if (!idRecordParam) throw new Error("Parametro idRecord assente");
 
-            const hasQueryParamsValues = [...idRecordParam.matchAll(/(%25|IN|=|%3D|,)/g)]
+      const hasQueryParamsValues = [...idRecordParam.matchAll(/(%25|IN|=|%3D|,)/g)]
 
-            if (!hasQueryParamsValues?.length) {
-                return parseInt(idRecordParam, 10);
-            }
+      if (!hasQueryParamsValues?.length) {
+        return parseInt(idRecordParam, 10);
+      }
 
-            const withoutInclusion = idRecordParam.split(/(%25|IN|=|%3D|,|%)/).filter((subStr) => typeof subStr === 'string' && !subStr.match(/(%25|IN|=|%3D|,|%)/));
-            const asStringsArray = withoutInclusion.filter(str => typeof str === 'string' && str.match(/[0-9]/));
-            const asNumsArray = asStringsArray.map(str => parseInt(str, 10));
+      const withoutInclusion = idRecordParam.split(/(%25|IN|=|%3D|,|%)/).filter((subStr) => typeof subStr === 'string' && !subStr.match(/(%25|IN|=|%3D|,|%)/));
+      const asStringsArray = withoutInclusion.filter(str => typeof str === 'string' && str.match(/[0-9]/));
+      const asNumsArray = asStringsArray.map(str => parseInt(str, 10));
 
-            return asNumsArray;
-        };
-
-        this.validateIdRecordParam = (idRecord) => {
-            if (!idRecord) {
-                throw new Error('idRecord mancante', idRecord);
-            };
-
-            if (Array.isArray(idRecord)) {
-                return `=%25IN=${idRecord.toString()}`;
-            }
-
-            return `=%25=${idRecord}`;
-        };
-
-        this.buildTableFromSchedaObj = (schedaObj) => {
-          // STRUCTURAL DOM ELEMENTS
-          const table = document.createElement('table');
-          table.setAttribute('border', '1');
-          table.style = {
-            borderCollapse: "collapse",
-            width: "100%"
-          };
-          const colGroup = document.createElement('colgroup');
-          Array.from({ length: 2 }).forEach((_v, index) => {
-            const col = document.createElement('col');
-            col.setAttribute('width', index < 1 ? '40%' : '70%');
-            colGroup.appendChild(col);
-          })
-          table.insertAdjacentElement('afterbegin', colGroup);
-          const tbody = document.createElement('tbody');
-          // DOM ELEMENTS BASED ON DATA
-          const objEntries = Object.entries(schedaObj);
-          const cellStyle = {
-            paddingLeft: "1%",
-            textAlign: "left",
-            textTransform: "capitalize",
-            whiteSpace: "wrap",
-            overflow: "hidden",
-          };
-          objEntries.forEach(([key, value]) => {
-            const tbodyRow = document.createElement('tr');
-            tbodyRow.style = {
-              minHeight: "18px",
-            };
-            const keyTd = document.createElement('td');
-            keyTd.textContent = [...key.replace('/[campo_]|_/gi', ' ')
-              .matchAll(/[^0-9|a-zA-Z]/gi)]
-              .toString()
-              .toUpperCase();
-            keyTd.style = { ...cellStyle, fontWeight: "bold" };
-            const valueTd = document.createElement('td');
-            valueTd.textContent = value + "";
-            valueTd.style = cellStyle;
-            tbodyRow.insertAdjacentElement('afterbegin', keyTd);
-            tbodyRow.insertAdjacentElement('beforeEnd', valueTd);
-            tbody.insertAdjacentElement('beforeend', tbodyRow);
-          })
-          return table;
-        }; 
+      return asNumsArray;
     };
 
-    window.angular
-        .module('reportApp.report')
-        .service('manageSchedeIdRecords', [
-            service
-        ]);
+    this.validateIdRecordParam = (idRecord) => {
+      if (!idRecord) {
+        throw new Error('idRecord mancante', idRecord);
+      };
+
+      if (Array.isArray(idRecord)) {
+        return `=%25IN=${idRecord.toString()}`;
+      }
+
+      return `=%25=${idRecord}`;
+    };
+
+    const getCampiSchedaValues = async (idRecord, templateId) => {
+      try {
+        const printModeInstructions = await reportService.getPrintModeInstructions(templateId)?.idScheda;
+        const templateIdScheda = await printModeInstructions?.idScheda;
+        console.log('---templateIdScheda OK---', typeof templateIdScheda, templateIdScheda);
+
+        if (!templateIdScheda) throw new Error('Id scheda da idRecord non presente. Tipo templateIdScheda: ', typeof templateIdScheda);
+
+        const valoriCampiScheda = await xdbApiService.getValoriCampiScheda(templateIdScheda, idRecord);
+        console.log('---valoriCampiScheda OK---', typeof valoriCampiScheda);
+
+        if (!valoriCampiScheda) throw new Error('Valori per campi scheda non presenti. Tipo valoriCampiScheda: ', typeof valoriCampiScheda);
+
+        return valoriCampiScheda;
+      } catch (error) {
+        console.error('Errore nell\'ottenere campi scheda.\n', error.message)
+        return null;
+      }
+    };
+
+    this.buildTableFromSchedaObj = (idRecord, templateId) => {
+      try {
+        // GET CAMPI SCHEDA VALUES
+        const campiSchedaValues = (async () => await getCampiSchedaValues(idRecord, templateId))();
+
+        // STRUCTURAL DOM ELEMENTS
+        const table = window.document.createElement('table');
+        table.setAttribute('border', '1');
+        table.style = {
+          borderCollapse: "collapse",
+          width: "100%"
+        };
+        const colGroup = window.document.createElement('colgroup');
+        Array.from({ length: 2 }).forEach((_v, index) => {
+          const col = window.document.createElement('col');
+          col.setAttribute('width', index < 1 ? '40%' : '70%');
+          colGroup.appendChild(col);
+        })
+        table.insertAdjacentElement('afterbegin', colGroup);
+        const tbody = window.document.createElement('tbody');
+
+        // DOM ELEMENTS BASED ON DATA
+        const cellStyle = {
+          paddingLeft: "1%",
+          textAlign: "left",
+          textTransform: "capitalize",
+          whiteSpace: "wrap",
+          overflow: "hidden",
+        };
+        campiSchedaValues.forEach((campo) => {
+          const tbodyRow = window.document.createElement('tr');
+          tbodyRow.style = {
+            minHeight: "18px",
+          };
+
+          const keyTd = window.document.createElement('td');
+          keyTd.textContent = campo?.etichetta.toUpperCase();
+          keyTd.style = { ...cellStyle, fontWeight: "bold" };
+          const valueTd = window.document.createElement('td');
+
+          valueTd.textContent = campo?.dettagli;
+          valueTd.style = cellStyle;
+          tbodyRow.insertAdjacentElement('afterbegin', keyTd);
+          tbodyRow.insertAdjacentElement('beforeEnd', valueTd);
+          tbody.insertAdjacentElement('beforeend', tbodyRow);
+        })
+
+        return table;
+      } catch (error) {
+        console.error("Errore nella creazione della tabella da idRecord.\n", error?.message);
+        const emptySpan = window.document.createElement('span');
+        return emptySpan;
+      }
+    };
+
+  };
+
+  window.angular
+    .module('reportApp.report')
+    .service('manageSchedeIdRecords', [
+      'xdbApiService',
+      'reportService',
+      service
+    ]);
 })();

--- a/server/public/modules/report/service/manageSchedeIdRecords.js
+++ b/server/public/modules/report/service/manageSchedeIdRecords.js
@@ -32,7 +32,7 @@
             return `=%25=${idRecord}`;
         };
 
-        const buildTableFromSchedaObj = (schedaObj) => {
+        this.buildTableFromSchedaObj = (schedaObj) => {
           // STRUCTURAL DOM ELEMENTS
           const table = document.createElement('table');
           table.setAttribute('border', '1');
@@ -77,18 +77,6 @@
           })
           return table;
         }; 
-
-        this.getTableFromSchedaObj = (scope, idRecord) => {
-            const schedaKey = Object.keys(scope).find((key) => key.startsWith('scheda_') && key.includes(`_${idRecord}`));
-            
-            if (!schedaKey) throw new Error(`Proprietà dello $scope per idRecord ${scope.infoBase.idRecord} non trovata`);
-                  
-            const schedaObj = JSON.stringify(scope[schedaKey]);
-
-            const table = buildTableFromSchedaObj(schedaObj);
-
-            return table;
-        }
     };
 
     window.angular

--- a/server/public/modules/report/service/manageSchedeIdRecords.js
+++ b/server/public/modules/report/service/manageSchedeIdRecords.js
@@ -1,5 +1,5 @@
 (function () {
-  const service = function (xdbApiService, reportService) {
+  const service = function () {
     this.getValidIdRecord = (searchParams) => {
       if (!searchParams) throw new Error("SearchParams assenti");
 
@@ -32,89 +32,11 @@
       return `=%25=${idRecord}`;
     };
 
-    const getCampiSchedaValues = async (idRecord, templateId) => {
-      try {
-        const printModeInstructions = await reportService.getPrintModeInstructions(templateId);
-        const templateIdScheda = await printModeInstructions?.idScheda;
-
-        if (!templateIdScheda) throw new Error('Id scheda da idRecord non presente. Tipo templateIdScheda: ', typeof templateIdScheda);
-
-        const valoriCampiScheda = await xdbApiService.getValoriCampiScheda(templateIdScheda, idRecord);
-
-        if (!valoriCampiScheda) throw new Error('Valori per campi scheda non presenti. Tipo valoriCampiScheda: ', typeof valoriCampiScheda);
-
-        return valoriCampiScheda?.data;
-      } catch (error) {
-        console.error('Errore nell\'ottenere campi scheda.\n', error.message)
-        return null;
-      }
-    };
-
-    this.buildTableFromSchedaObj = async (idRecord, templateId) => {
-      try {
-        // GET CAMPI SCHEDA VALUES
-        const campiSchedaValues = await getCampiSchedaValues(idRecord, templateId);
-
-        if (!campiSchedaValues) throw new Error('campiSchedaValues non esistenti. Tipo campiSchedaValues: ', typeof campiSchedaValues);
-
-        // STRUCTURAL DOM ELEMENTS
-        const table = window.document.createElement('table');
-        table.setAttribute('border', '1');
-        table.style = {
-          borderCollapse: "collapse",
-          width: "100%"
-        };
-        const colGroup = window.document.createElement('colgroup');
-        Array.from({ length: 2 }).forEach((_v, index) => {
-          const col = window.document.createElement('col');
-          col.setAttribute('width', index < 1 ? '40%' : '70%');
-          colGroup.appendChild(col);
-        })
-        table.insertAdjacentElement('afterbegin', colGroup);
-        const tbody = window.document.createElement('tbody');
-        table.insertAdjacentElement('beforeend', tbody);
-
-        // DOM ELEMENTS BASED ON DATA
-        const cellStyle = {
-          paddingLeft: "1%",
-          textAlign: "left",
-          textTransform: "capitalize",
-          whiteSpace: "wrap",
-          overflow: "hidden",
-        };
-        campiSchedaValues.forEach((campo) => {
-          const tbodyRow = window.document.createElement('tr');
-          tbodyRow.style = {
-            minHeight: "18px",
-          };
-
-          const keyTd = window.document.createElement('td');
-          keyTd.textContent = campo?.etichetta.toUpperCase();
-          keyTd.style = { ...cellStyle, fontWeight: "bold" };
-          const valueTd = window.document.createElement('td');
-
-          valueTd.textContent = campo?.dettagli;
-          valueTd.style = cellStyle;
-          tbodyRow.insertAdjacentElement('afterbegin', keyTd);
-          tbodyRow.insertAdjacentElement('beforeEnd', valueTd);
-          tbody.insertAdjacentElement('beforeend', tbodyRow);
-        })
-
-        return table;
-      } catch (error) {
-        console.error("Errore nella creazione della tabella da idRecord.\n", error?.message);
-        const emptySpan = window.document.createElement('span');
-        return emptySpan;
-      }
-    };
-
   };
 
   window.angular
     .module('reportApp.report')
     .service('manageSchedeIdRecords', [
-      'xdbApiService',
-      'reportService',
       service
     ]);
 })();

--- a/server/public/modules/report/service/manageSchedeIdRecords.js
+++ b/server/public/modules/report/service/manageSchedeIdRecords.js
@@ -22,7 +22,7 @@
 
     this.validateIdRecordParam = (idRecord) => {
       if (!idRecord) {
-        throw new Error('idRecord mancante', idRecord);
+        throw new Error('idRecord mancante', typeof idRecord);
       };
 
       if (Array.isArray(idRecord)) {
@@ -31,6 +31,24 @@
 
       return `=%25=${idRecord}`;
     };
+
+    this.makeVistaRowsQueryParams = (queryKey, idRecord) => {
+      if (!idRecord) {
+        throw new Error('idRecord mancante', typeof idRecord);
+      };
+
+      if (!queryKey) {
+        throw new Error('queryKey mancante', typeof queryKey);
+      };
+
+      if (!queryKey) return null;
+
+      if (!Array.isArray(idRecord)) {
+        return `${queryKey}${this.validateIdRecordParam(idRecord)}`;
+      }
+
+      return idRecord.map((idR) => `${queryKey}${this.validateIdRecordParam(idR)}`)
+     };
 
   };
 

--- a/server/public/modules/report/service/manageSchedeIdRecords.js
+++ b/server/public/modules/report/service/manageSchedeIdRecords.js
@@ -34,28 +34,28 @@
 
     const getCampiSchedaValues = async (idRecord, templateId) => {
       try {
-        const printModeInstructions = await reportService.getPrintModeInstructions(templateId)?.idScheda;
+        const printModeInstructions = await reportService.getPrintModeInstructions(templateId);
         const templateIdScheda = await printModeInstructions?.idScheda;
-        console.log('---templateIdScheda OK---', typeof templateIdScheda, templateIdScheda);
 
         if (!templateIdScheda) throw new Error('Id scheda da idRecord non presente. Tipo templateIdScheda: ', typeof templateIdScheda);
 
         const valoriCampiScheda = await xdbApiService.getValoriCampiScheda(templateIdScheda, idRecord);
-        console.log('---valoriCampiScheda OK---', typeof valoriCampiScheda);
 
         if (!valoriCampiScheda) throw new Error('Valori per campi scheda non presenti. Tipo valoriCampiScheda: ', typeof valoriCampiScheda);
 
-        return valoriCampiScheda;
+        return valoriCampiScheda?.data;
       } catch (error) {
         console.error('Errore nell\'ottenere campi scheda.\n', error.message)
         return null;
       }
     };
 
-    this.buildTableFromSchedaObj = (idRecord, templateId) => {
+    this.buildTableFromSchedaObj = async (idRecord, templateId) => {
       try {
         // GET CAMPI SCHEDA VALUES
-        const campiSchedaValues = (async () => await getCampiSchedaValues(idRecord, templateId))();
+        const campiSchedaValues = await getCampiSchedaValues(idRecord, templateId);
+
+        if (!campiSchedaValues) throw new Error('campiSchedaValues non esistenti. Tipo campiSchedaValues: ', typeof campiSchedaValues);
 
         // STRUCTURAL DOM ELEMENTS
         const table = window.document.createElement('table');
@@ -72,6 +72,7 @@
         })
         table.insertAdjacentElement('afterbegin', colGroup);
         const tbody = window.document.createElement('tbody');
+        table.insertAdjacentElement('beforeend', tbody);
 
         // DOM ELEMENTS BASED ON DATA
         const cellStyle = {

--- a/server/public/modules/report/service/manageSchedeIdRecords.js
+++ b/server/public/modules/report/service/manageSchedeIdRecords.js
@@ -32,7 +32,7 @@
             return `=%25=${idRecord}`;
         };
 
-        this.buildTableFromSchedaObj = (schedaObj) => {
+        const buildTableFromSchedaObj = (schedaObj) => {
           // STRUCTURAL DOM ELEMENTS
           const table = document.createElement('table');
           table.setAttribute('border', '1');
@@ -77,6 +77,18 @@
           })
           return table;
         }; 
+
+        this.getTableFromSchedaObj = (scope, idRecord) => {
+            const schedaKey = Object.keys(scope).find((key) => key.startsWith('scheda_') && key.includes(`_${idRecord}`));
+            
+            if (!schedaKey) throw new Error(`Proprietà dello $scope per idRecord ${scope.infoBase.idRecord} non trovata`);
+                  
+            const schedaObj = JSON.stringify(scope[schedaKey]);
+
+            const table = buildTableFromSchedaObj(schedaObj);
+
+            return table;
+        }
     };
 
     window.angular

--- a/server/public/modules/report/service/manageSchedeIdRecords.js
+++ b/server/public/modules/report/service/manageSchedeIdRecords.js
@@ -1,0 +1,87 @@
+(function () {
+    const service = function () {
+        this.getValidIdRecord = (searchParams) => {
+            if (!searchParams) throw new Error("SearchParams assenti");
+
+            const idRecordParam = searchParams.get('idRecord');
+
+            if (!idRecordParam) throw new Error("Parametro idRecord assente");
+
+            const hasQueryParamsValues = [...idRecordParam.matchAll(/(%25|IN|=|%3D|,)/g)]
+
+            if (!hasQueryParamsValues?.length) {
+                return parseInt(idRecordParam, 10);
+            }
+
+            const withoutInclusion = idRecordParam.split(/(%25|IN|=|%3D|,|%)/).filter((subStr) => typeof subStr === 'string' && !subStr.match(/(%25|IN|=|%3D|,|%)/));
+            const asStringsArray = withoutInclusion.filter(str => typeof str === 'string' && str.match(/[0-9]/));
+            const asNumsArray = asStringsArray.map(str => parseInt(str, 10));
+
+            return asNumsArray;
+        };
+
+        this.validateIdRecordParam = (idRecord) => {
+            if (!idRecord) {
+                throw new Error('idRecord mancante', idRecord);
+            };
+
+            if (Array.isArray(idRecord)) {
+                return `=%25IN=${idRecord.toString()}`;
+            }
+
+            return `=%25=${idRecord}`;
+        };
+
+        this.buildTableFromSchedaObj = (schedaObj) => {
+          // STRUCTURAL DOM ELEMENTS
+          const table = document.createElement('table');
+          table.setAttribute('border', '1');
+          table.style = {
+            borderCollapse: "collapse",
+            width: "100%"
+          };
+          const colGroup = document.createElement('colgroup');
+          Array.from({ length: 2 }).forEach((_v, index) => {
+            const col = document.createElement('col');
+            col.setAttribute('width', index < 1 ? '40%' : '70%');
+            colGroup.appendChild(col);
+          })
+          table.insertAdjacentElement('afterbegin', colGroup);
+          const tbody = document.createElement('tbody');
+          // DOM ELEMENTS BASED ON DATA
+          const objEntries = Object.entries(schedaObj);
+          const cellStyle = {
+            paddingLeft: "1%",
+            textAlign: "left",
+            textTransform: "capitalize",
+            whiteSpace: "wrap",
+            overflow: "hidden",
+          };
+          objEntries.forEach(([key, value]) => {
+            const tbodyRow = document.createElement('tr');
+            tbodyRow.style = {
+              minHeight: "18px",
+            };
+            const keyTd = document.createElement('td');
+            keyTd.textContent = [...key.replace('/[campo_]|_/gi', ' ')
+              .matchAll(/[^0-9|a-zA-Z]/gi)]
+              .toString()
+              .toUpperCase();
+            keyTd.style = { ...cellStyle, fontWeight: "bold" };
+            const valueTd = document.createElement('td');
+            valueTd.textContent = value + "";
+            valueTd.style = cellStyle;
+            tbodyRow.insertAdjacentElement('afterbegin', keyTd);
+            tbodyRow.insertAdjacentElement('beforeEnd', valueTd);
+            tbody.insertAdjacentElement('beforeend', tbodyRow);
+          })
+          return table;
+        }; 
+    };
+
+    window.angular
+        .module('reportApp.report')
+        .service('manageSchedeIdRecords', [
+            service
+        ]);
+})();

--- a/server/public/modules/report/service/reportHelpers.js
+++ b/server/public/modules/report/service/reportHelpers.js
@@ -1,0 +1,100 @@
+'use strict';
+(function () {
+    const service = function () {
+        const getPlaceholdersScheda = function (template) {
+            const matched = template.match(/{{scheda_[0-9a-zA-Z](.*?)}}/g) || [];
+            const placeholdersScheda = matched.map(function (val) {
+                return val.replace(/({{|}})/g, '');
+            });
+            return placeholdersScheda;
+        };
+
+        const getPlaceholdersViste = function (template) {
+            const matched = template.match(/"item in vista_(.*?)"/g) || [];
+            const placeholdersViste = matched.map(function (val) {
+                return val.replace(/(ng-repeat=|"|item in )/g, '').replace(/ \| orderBy:'(.*?)'/g, '');
+            });
+            return placeholdersViste;
+        };
+
+        const getPlaceholdersVisteSingole = function (template) {
+            const matched = template.match(/{{vista_(.*?)[0-9](.*?)}}/g) || [];
+
+            const placeholdersViste = matched.map(function (val) {
+                return val.replace(/({{|}})/g, '');
+            });
+
+            return placeholdersViste;
+        };
+        const deSanitizeId = function (number) {
+            const string = number + '';
+            return string.toLowerCase().replace(/\[.*\]/g, '').split('pers').join('-');
+        };
+
+        const sanitizeSlug = function (string) {
+            if (!string) {
+                return '_' + new Date().getTime();
+            }
+            return string.replace(/\([^()]*\)/g, '').replace(/\s+$/, '').normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^\w\s]/gi, '').toLowerCase().split(' ').join('_');
+        };
+
+        this.getIdScheda = function (template) {
+            const placeholdersScheda = getPlaceholdersScheda(template);
+            const idsPlaceholders = placeholdersScheda.map(function (placeholder) {
+                const schedaInfo = placeholder.split('.')[0];
+                const schedaInfoArray = schedaInfo.split('_');
+                const schedaInfoId = schedaInfoArray[schedaInfoArray.length - 1];
+                return parseInt(schedaInfoId, 10);
+            });
+
+            return idsPlaceholders[0];
+        };
+
+        this.getIdViste = function (template) {
+            let placeholdersViste = getPlaceholdersViste(template);
+            const placeholdersVisteSingole = getPlaceholdersVisteSingole(template);
+            placeholdersViste = placeholdersViste.concat(placeholdersVisteSingole);
+            const idsPlaceholders = placeholdersViste.map(function (placeholder) {
+                const vistaInfo = deSanitizeId(placeholder.split('.')[0]);
+                const vistaInfoArray = vistaInfo.split('_');
+                const vistaInfoId = vistaInfoArray[vistaInfoArray.length - 1];
+                return parseInt(vistaInfoId, 10);
+            });
+
+            return idsPlaceholders;
+        };
+
+        this.mapSchedaToReportData = function (infoScheda, valori) {
+            const toReturn = {};
+            valori.forEach(function (valore) {
+                const content = valore.dettagli ? valore.dettagli : valore.valore;
+
+                const schedaKey = 'scheda_' + sanitizeSlug(infoScheda.nomeScheda) + '_' + infoScheda.idScheda;
+                const campoKey = 'campo_' + sanitizeSlug(valore.etichetta) + '_' + valore.idCampoScheda;
+
+                if (!toReturn[schedaKey]) {
+                    toReturn[schedaKey] = {};
+                }
+
+                toReturn[schedaKey][campoKey] = content;
+            });
+
+            return toReturn;
+        };
+
+        this.mapVistaToReportData = function (infoVista, valori) {
+            const toReturn = {};
+            const stringIdVista = infoVista.idVista + '';
+            const idVistaSanitized = stringIdVista.replace(/-/g, 'pers');
+            toReturn['vista_' + sanitizeSlug(infoVista.etichettaVista) + '_' + idVistaSanitized] = valori.records;
+
+            return toReturn;
+        };
+    };
+
+    window.angular
+        .module('reportApp.report')
+        .service('reportHelpers', [
+            service
+        ]);
+})();

--- a/server/public/modules/report/service/reportService.js
+++ b/server/public/modules/report/service/reportService.js
@@ -31,16 +31,22 @@
           });
       };
 
-      const getApiTemplateCss = async function (templateId) {
+      const getPrintModeInstructions = async function (templateId) {
         const url = `${apiURLs.getBasePath()}/${TEMPLATE_BASE_URL}/${templateId}`;
 
-        const response = await xdbHttpService
+        return xdbHttpService
           .fetch({
             method: 'GET',
             url: url
-          })
+          }).then(function (res) {
+            return res.data;
+          });
+      }
+
+      const getApiTemplateCss = async function (templateId) {
+        const queryResponse = await getPrintModeInstructions(templateId);
         
-        const customStyle = await response?.data?.customStyle || ""; 
+        const customStyle = await queryResponse?.customStyle || ""; 
         
         return customStyle;
       }
@@ -76,7 +82,8 @@
         getTemplate,
         getVisteTemplate,
         getDatiSchedaDiRiferimento,
-        getApiTemplateCss
+        getApiTemplateCss,
+        getPrintModeInstructions
       };
     }
   ]);


### PR DESCRIPTION
## Esigenze feat:
Adattare il codice del puppeteer di modo che sia in grado di gestire quanto eseguito sul client per questa feat:

> Modificare l’editor dei report per fare in modo di ottenere gli ID records passati come input al report.
> 
> Esiste già un’istruzione nel menù che appare al click con il tasto DX del mouse nell’editor chiamata “Inserisci un’informazione globale” con un sottomenù che mostra tutti i campi scheda della scheda di riferimento del report.
> 
> L’istruzione in questione è “idRecord” che aggiunge al source code del report il comando {{infoBase.idRecord}}
> 
> L’intento è quello di ottenere una cosa simile ma che invece di un solo ID record mi vengano ritornati tutti gli ID record forniti al report.
> 
> In fase di sviluppo del report, l’editor permette di selezionare un solo record da utilizzare in Anteprima tramite il relativo menù a tendina posto sulla DX dell’editor.
> 
> Per ottenere questa funzionalità si può pensare di:
> 
> Rendere l’attuale menù a tendina per la scelta di un record di esempio un menù con la possibilità di selezionare più di un record (attraverso delle checkbox)
> 
> Creare una nuova istruzione nel sotto-menù “Inserisci un’informazione globale” chiamata “Lista ID record (??)” che:
> 
> Aggiunga nel source code dell’edito un’istruzione che permette di ciclare questi ID record. Es:
> 
 ```
<div data-ng-repeat="record in lista_record">
	...
 </div>
 ```

---

## Cosa comprende questa pr:

In app.js: 
- corretto messaggio di errore restituito da `getErrorMessage()`: rimosso `error.textContent.
- aggiunta una gestione differenziata del dato `idRecord` attraverso il file secondo il formato recepito: se il search param dell'url da cui il dato viene ricavato comprende più riferimenti, verrà trattato come array; altrimenti verrà trattato come numero
- indicata logica parziale per l'assegnazione allo `$scope` dei valori dinamici di viste e schede utilizzati dal template del report 

In manageSchedeIdRecords.js:
- aggiunto service per raccogliere e restituire le funzioni relative alla manipolazione del dato `idRecord` proveniente dal search param `idRecord` nei diversi formati 
- creata funzione `makeVistaRowsQueryParams` per generare dinamicamente il valore corrispondente in base al search param desiderato per la query verso  `/data/vista-rows/${templateId}?${...queryParams}` e l'`idRecord` ricavato in precedenza

In reportService.js:
- isolata query verso path templates/idTemplate: estratta query verso path templates/templateId da getApiTemplateCss e
risolta in una funzione indipendente. Questo per agevolare un riutilizzo della stessa risposta in futuro e in altri services senza dipendere troppo dalla gestione di dati simili in `app.js`. 