### PR TITLE
fix: lettura dello stile css per il footer dei report (Rif.Int.: 2025/ 4927)

### DIFF
--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -147,7 +147,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
             height: ${headerHeight ? headerHeight + SBECCO : '0'}px;
           }
 
-          .document-table-footer, .page-footer {
+          .page-footer, .page-footer-space {
             height: ${FOOTER_H ? FOOTER_H + SBECCO : '0'}px;
           }
   
@@ -157,9 +157,6 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
             left: 0;
             right: 0;
             background-color: #fff;
-          }
-
-          div.page-footer-space {
             padding-bottom: 0px;
             width: 100%; 
             font-size: 9px; 
@@ -286,7 +283,10 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
                 </tr>
               </tbody>
               <tfoot>
-                <tr class="document-table-footer">
+                <tr>
+                <td>
+                <div class="page-footer-space"></div>
+                </td>
                   </tr>
                   </tfoot>
                   </table>

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -217,7 +217,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
           `;
         return CUSTOM_CSS;
       };
-            
+
       const CUSTOM_CSS = getCustomCSS(HEADER_H, addedStyle);
 
       const addFooter = () => {
@@ -227,7 +227,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       }
 
       const getHTMLReportFromContent = function (bodyHTML, headerHTML) {
-        
+
         return `
         <style>${CUSTOM_CSS}</style>
             <div id="header" class="page-header">

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -147,7 +147,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
             height: ${headerHeight ? headerHeight + SBECCO : '0'}px;
           }
 
-          .document-table-footer {
+          .document-table-footer, .page-footer {
             height: ${FOOTER_H ? FOOTER_H + SBECCO : '0'}px;
           }
   
@@ -157,6 +157,15 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
             left: 0;
             right: 0;
             background-color: #fff;
+          }
+
+          div.page-footer-space {
+            padding-bottom: 0px;
+            width: 100%; 
+            font-size: 9px; 
+            text-align: center; 
+            font-family: Arial; 
+            color: #444;
           }
   
           .page-header {
@@ -205,20 +214,6 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
             break-inside: avoid;
             orphans: 0;
             widows: 4;
-          }
-
-          div.page-footer-space {
-            position: fixed;
-            left: 0;
-            bottom: 0;
-            padding-bottom: 0px;
-            width: 100%; 
-            background-color: #fff; 
-            font-size: 9px; 
-            text-align: center; 
-            padding: 5px 0 0 0; 
-            font-family: Arial; 
-            color: #444;
           }
 
           ${addedStyle ?? ""}
@@ -296,7 +291,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
                   </tfoot>
                   </table>
 
-                  <div class="page-footer-space standard-padding">
+                  <div class="page-footer page-footer-space standard-padding">
                     ${addFooter()}
                   </div>
           `;

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -284,15 +284,14 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
                 </tr>
               </tbody>
               <tfoot>
-                <tr>
-                  <td>
-                    <div class="page-footer-space">
-                      ${addFooter()}
-                    </div>
-                  </td>
-                </tr>
-              </tfoot>
-            </table>
+                <tr class="document-table-footer">
+                  </tr>
+                  </tfoot>
+                  </table>
+
+                  <div class="page-footer-space standard-padding">
+                    ${addFooter()}
+                  </div>
           `;
       };
 

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -146,7 +146,10 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
           .page-header, .page-header-space {
             height: ${headerHeight ? headerHeight + SBECCO : '0'}px;
           }
-  
+
+          .document-table-footer {
+            height: ${FOOTER_H ? FOOTER_H + SBECCO : '0'}px;
+          }
   
           .page-footer {
             position: fixed;

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -151,7 +151,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
             height: ${FOOTER_H ? FOOTER_H + SBECCO : '0'}px;
           }
   
-          .page-footer {
+          div.page-footer {
             position: fixed;
             bottom: 0;
             left: 0;
@@ -291,7 +291,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
                   </tfoot>
                   </table>
 
-                  <div class="page-footer page-footer-space standard-padding">
+                  <div class="page-footer standard-padding">
                     ${addFooter()}
                   </div>
           `;

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -117,7 +117,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       }));
     });
 
-    const { FOOTER_TEMPLATE, HAS_FOOTER, FOOTER_H } = await page.evaluate((addedStyle) => {
+    const { FOOTER_H } = await page.evaluate((addedStyle) => {
 
       const SBECCO = 20;
 
@@ -204,12 +204,28 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
             widows: 4;
           }
 
+          div.page-footer-space {
+            width: 100%; 
+            background-color: #fff; 
+            font-size: 9px; 
+            text-align: center; 
+            padding: 5px 0 0 0; 
+            font-family: Arial; 
+            color: #444;
+          }
+
           ${addedStyle ?? ""}
           `;
         return CUSTOM_CSS;
       };
             
       const CUSTOM_CSS = getCustomCSS(HEADER_H, addedStyle);
+
+      const addFooter = () => {
+        if (!HAS_FOOTER) return "";
+
+        return FOOTER_TEMPLATE;
+      }
 
       const getHTMLReportFromContent = function (bodyHTML, headerHTML) {
         
@@ -270,7 +286,9 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
               <tfoot>
                 <tr>
                   <td>
-                    <div class="page-footer-space"></div>
+                    <div class="page-footer-space">
+                      ${addFooter()}
+                    </div>
                   </td>
                 </tr>
               </tfoot>
@@ -282,8 +300,6 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       document.querySelector('body').innerHTML = `${TEMPLATE}`;
 
       return {
-        FOOTER_TEMPLATE,
-        HAS_FOOTER,
         FOOTER_H
       };
     }, apiCss);
@@ -309,17 +325,6 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
 
     if (IS_LANDSCAPE) {
       config.landscape = true;
-    }
-
-    if (HAS_FOOTER) {
-      config.displayHeaderFooter = true;
-      config.margin = {
-        top: 0,
-        right: 0,
-        left: 0,
-        bottom: FOOTER_H || 40
-      };
-      config.footerTemplate = `<div style="width: 100%; background-color: #fff; font-size: 9px; text-align: center; padding: 5px 0 0 0; font-family: Arial; color: #444;">${FOOTER_TEMPLATE}</div>`;
     }
 
     if (IS_PAGE_NUMBER_VISIBLE) {

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -208,6 +208,10 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
           }
 
           div.page-footer-space {
+            position: fixed;
+            left: 0;
+            bottom: 0;
+            padding-bottom: 0px;
             width: 100%; 
             background-color: #fff; 
             font-size: 9px; 

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -223,7 +223,9 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       const addFooter = () => {
         if (!HAS_FOOTER) return "";
 
-        return FOOTER_TEMPLATE;
+        return `<div class="page-footer standard-padding">
+        ${FOOTER_TEMPLATE}
+        </div>`;
       }
 
       const getHTMLReportFromContent = function (bodyHTML, headerHTML) {
@@ -291,9 +293,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
                   </tfoot>
                   </table>
 
-                  <div class="page-footer standard-padding">
                     ${addFooter()}
-                  </div>
           `;
       };
 


### PR DESCRIPTION
## Esigenza del fix:
A seguito dello sviluppo di applicazione di un CSS custom da parte dell’utente ci siamo accorti che non viene applicato nessun CSS alla sezione footer del report a differenza della sezione header e body che viene correttamente applicato.

Si chiede quindi di:

- Sistemare l’applicazione del CSS anche nel footer così come avviene nell’header e nel body

---
## Cosa comprende questa pr:
- aggiunta funzione per iniettare il footer proveniente dal client nel template del report con blocco condizionale: addFooter()
- rimossa configurazione del footer del puppeteer tramite api del puppeteer
- aggiunto stile dichiarato inline durante la costruzione del footer tramite api del puppeteer in classe .page-footer
- formattazione files