### PR TITLE
fix: rimozione stile inline footer (Rif.Int.: 2025/ 4928)

### DIFF
--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -152,10 +152,6 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
           }
   
           .page-footer {
-            position: fixed;
-            bottom: 0;
-            left: 0;
-            right: 0;
             width: 100%; 
             background-color: #fff; 
             font-size: 9px; 
@@ -165,12 +161,15 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
             font-family: Arial; 
             color: #444;
           }
-  
-          .page-footer--with-numbers {
+
+          .page-footer--fixed {
             position: fixed;
+            bottom: 0;
             left: 0;
             right: 0;
-            bottom: ${SBECCO}px;
+          }
+  
+          .page-footer--with-numbers {
             display: flex; 
             flex-direction: column; 
             align-items: center; 
@@ -350,7 +349,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       <style>
       ${CUSTOM_CSS}
       </style>
-      <div class="page-footer">
+      <div class="page-footer page-footer--fixed">
       ${FOOTER_TEMPLATE}
       </div>`;
     }

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -163,6 +163,10 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
           }
   
           .page-footer--with-numbers {
+            position: fixed;
+            left: 0;
+            right: 0;
+            bottom: ${SBECCO}px;
             display: flex; 
             flex-direction: column; 
             align-items: center; 

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -133,6 +133,10 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
 
       const getCustomCSS = function (headerHeight, addedStyle) {
         const CUSTOM_CSS = `
+          html {
+              -webkit-print-color-adjust: exact;
+            }
+
           .document-preview__frame__page-break-after {
             width: 100%;
             border: none;
@@ -197,6 +201,10 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
           }
   
           @media print {
+            html {
+              -webkit-print-color-adjust: exact;
+            }
+
             thead {display: table-header-group;} 
             tfoot {display: table-footer-group;}
             button {display: none;}
@@ -348,6 +356,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
         left: 0,
         bottom: FOOTER_H ? FOOTER_H + 40 : 40
       };
+      config.printBackground = true;
       config.footerTemplate = `<style>
         ${CUSTOM_CSS}
       </style>

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -224,8 +224,6 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
             
       const CUSTOM_CSS = getCustomCSS(HEADER_H, addedStyle);
 
-      console.log('CUSTOM_CSS', CUSTOM_CSS);
-
       const getHTMLReportFromContent = function (bodyHTML, headerHTML) {
         
         return `

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -221,11 +221,11 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
           `;
         return CUSTOM_CSS;
       };
-            
+
       const CUSTOM_CSS = getCustomCSS(HEADER_H, addedStyle);
 
       const getHTMLReportFromContent = function (bodyHTML, headerHTML) {
-        
+
         return `
         <style>${CUSTOM_CSS}</style>
             <div id="header" class="page-header">

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -368,7 +368,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
         ${CUSTOM_CSS}
       </style>
       <div class="page-footer page-footer--with-numbers">
-        ${!config?.footerTemplate ? "" : config?.footerTemplate }
+        ${!HAS_FOOTER ? "" : FOOTER_TEMPLATE}
         <div id="page-numbers-container" class="page-footer">
           Pagina <span class="pageNumber"></span> di <span class="totalPages"></span>
         </div>

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -342,7 +342,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
         top: 0,
         right: 0,
         left: 0,
-        bottom: FOOTER_H || 40
+        bottom: FOOTER_H + 40 || 40
       };
       config.printBackground = true;
       config.footerTemplate = `

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -101,7 +101,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
 
     const WIDTH = body.width + 'mm';
     const HEIGHT = body.height + 'mm';
-    const IS_PAGE_NUMBER_VISIBLE = body.pageNumber;
+    const IS_PAGE_NUMBER_VISIBLE = body.insertPageNumber;
 
     await page.waitForSelector('#header', { timeout: 0, visible: true });
     await page.waitForSelector('#footer', { timeout: 0, visible: true });

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -345,6 +345,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
         left: 0,
         bottom: FOOTER_H || 40
       };
+      config.printBackground = true;
       config.footerTemplate = `<div style="width: 100%; background-color: #fff; font-size: 9px; text-align: center; padding: 5px 0 0 0; font-family: Arial; color: #444;">${FOOTER_TEMPLATE}</div>`;
     }
 

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -164,7 +164,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
 
           .page-footer--fixed {
             position: fixed;
-            bottom: 0;
+            bottom: ${SBECCO}px;
             left: 0;
             right: 0;
           }
@@ -366,7 +366,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       config.footerTemplate = `<style>
         ${CUSTOM_CSS}
       </style>
-      <div class="page-footer page-footer--with-numbers">
+      <div class="page-footer page-footer--with-numbers page-footer--fixed">
         ${!HAS_FOOTER ? "" : FOOTER_TEMPLATE}
         <div id="page-numbers-container" class="page-footer">
           Pagina <span class="pageNumber"></span> di <span class="totalPages"></span>

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -224,6 +224,8 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
             
       const CUSTOM_CSS = getCustomCSS(HEADER_H, addedStyle);
 
+      console.log('CUSTOM_CSS', CUSTOM_CSS);
+
       const getHTMLReportFromContent = function (bodyHTML, headerHTML) {
         
         return `
@@ -348,7 +350,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       </style>
       <div class="page-footer page-footer--with-numbers">
         ${config.footerTemplate}
-        <div class="page-footer">
+        <div id="page-numbers-container" class="page-footer">
           Pagina <span class="pageNumber"></span> di <span class="totalPages"></span>
         </div>
       </div>`;

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -117,7 +117,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       }));
     });
 
-    const { FOOTER_TEMPLATE, HAS_FOOTER, FOOTER_H } = await page.evaluate((addedStyle) => {
+    const { FOOTER_TEMPLATE, HAS_FOOTER, FOOTER_H, CUSTOM_CSS } = await page.evaluate((addedStyle) => {
 
       const SBECCO = 20;
 
@@ -146,7 +146,6 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
           .page-header, .page-header-space {
             height: ${headerHeight ? headerHeight + SBECCO : '0'}px;
           }
-  
   
           .page-footer {
             position: fixed;
@@ -298,7 +297,8 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       return {
         FOOTER_TEMPLATE,
         HAS_FOOTER,
-        FOOTER_H
+        FOOTER_H,
+        CUSTOM_CSS
       };
     }, apiCss);
 

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -153,9 +153,23 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
             bottom: 0;
             left: 0;
             right: 0;
-            background-color: #fff;
+            width: 100%; 
+            background-color: #fff; 
+            font-size: 9px; 
+            text-align: 
+            center; 
+            padding: 5px 0 0 0; 
+            font-family: Arial; 
+            color: #444;
           }
   
+          .page-footer--with-numbers {
+            display: flex; 
+            flex-direction: column; 
+            align-items: center; 
+            justify-content: center;
+          }
+
           .page-header {
             position: fixed;
             top: 0mm;

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -341,6 +341,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
     }
 
     if (IS_PAGE_NUMBER_VISIBLE) {
+      config.displayHeaderFooter = true;
       config.margin = {
         top: 0,
         right: 0,
@@ -351,7 +352,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
         ${CUSTOM_CSS}
       </style>
       <div class="page-footer page-footer--with-numbers">
-        ${config.footerTemplate}
+        ${!config?.footerTemplate ? "" : config?.footerTemplate }
         <div id="page-numbers-container" class="page-footer">
           Pagina <span class="pageNumber"></span> di <span class="totalPages"></span>
         </div>

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -343,9 +343,12 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
         left: 0,
         bottom: FOOTER_H ? FOOTER_H + 40 : 40
       };
-      config.footerTemplate = `<div style="width: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center;">
+      config.footerTemplate = `<style>
+        ${CUSTOM_CSS}
+      </style>
+      <div class="page-footer page-footer--with-numbers">
         ${config.footerTemplate}
-        <div style="width: 100%; margin-top: 10px; font-size: 9px; text-align: center; padding: 5px 0 0 0; font-family: Arial; color: #444;">
+        <div class="page-footer">
           Pagina <span class="pageNumber"></span> di <span class="totalPages"></span>
         </div>
       </div>`;

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -101,7 +101,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
 
     const WIDTH = body.width + 'mm';
     const HEIGHT = body.height + 'mm';
-    const IS_PAGE_NUMBER_VISIBLE = body.insertPageNumber;
+    const IS_PAGE_NUMBER_VISIBLE = body.pageNumber;
 
     await page.waitForSelector('#header', { timeout: 0, visible: true });
     await page.waitForSelector('#footer', { timeout: 0, visible: true });

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -164,7 +164,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
 
           .page-footer--fixed {
             position: fixed;
-            bottom: ${SBECCO}px;
+            bottom: 0px;
             left: 0;
             right: 0;
           }
@@ -360,7 +360,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
         top: 0,
         right: 0,
         left: 0,
-        bottom: FOOTER_H ? FOOTER_H + 40 : 40
+        bottom: HAS_FOOTER ? FOOTER_H + 40 : 40
       };
       config.printBackground = true;
       config.footerTemplate = `<style>


### PR DESCRIPTION
## Esigenze del fix:

Nel progetto del puppeteer, durante la costruzione della pagina in caso di visualizzazione del numero di pagina nel report viene applicato un blocco html così composto:

```
// printer.js row 325
if (IS_PAGE_NUMBER_VISIBLE) {
      config.margin = {
        top: 0,
        right: 0,
        left: 0,
        bottom: FOOTER_H ? FOOTER_H + 40 : 40
      };
      config.footerTemplate = `<div style="width: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center;">
        ${config.footerTemplate}
        <div style="width: 100%; margin-top: 10px; font-size: 9px; text-align: center; padding: 5px 0 0 0; font-family: Arial; color: #444;">
          Pagina <span class="pageNumber"></span> di <span class="totalPages"></span>
        </div>
      </div>`;
    }
```
Siccome ci viene chiesto di poter spostare il posizionamento del numero di pagina (attualmente viene messo sempre al centro della pagina) si può provare una soluzione del genere:

Racchiudere tutto lo stile in-line del <div> contenente il numero di pagina in una classe specifica all’interno del puppeteer

Verifiche post sviluppo:
- Provare nella configurazione del report a sovrascrivere il posizionamento del numero di pagina attraverso un CSS custom

--- 

## Cosa comprende questa pr: 

Il frammento del footer contenente la paginazione, essendo definito tramite le api di `page.pdf()` del puppeteer, non può comunicare con le altre risorse esterne - siano esse stylesheets oppure frammenti del dom come quello definito all'interno di `await page.evaluate` a riga 124. Anche l'import dello stile aggiunto tramite `page.addStyleTag()` a riga 349 non sembra funzionare. Ciò è probabilmente dovuto ad un bug proprio della libreria, come segnalato dagli issues che riporto di seguito:
- [footerTemplate and headerTemplate don't use body styles](https://github.com/puppeteer/puppeteer/issues/1853)
- [Scripts are not evalutated in header and footer HTML templates for PDFs.](https://github.com/puppeteer/puppeteer/issues/2167#event-645755896)
- [Full CSS Style support in header and footer html and Loading external Resources](https://github.com/puppeteer/puppeteer/issues/4254)

Pertanto, in attesa di poter studiare una soluzione più elegante per una paginazione dei fogli di stampa, ho 
- aggiunto degli ulteriori tag style che replichino lo stile css definito all'interno di `await page.evaluate` a riga 124
- corretto il nome della proprietà del body contenente il template del report definito per la costante `IS_PAGE_NUMBER_VISIBLE` a riga 104
- sostituito gli stili inline con delle classi e 
- aggiunto un id al contenitore degli span con la paginazione per consentire una maggiore precisione nel vincere le regole di specificità nella definizione di uno stile

  ---
  ## Files modificati:
  - server/lib/printer.js