### PR TITLE
fix: lettura dello stile css per il footer dei report (Rif.Int.: 2025/ 4927)

### DIFF
--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -328,7 +328,13 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
         left: 0,
         bottom: FOOTER_H || 40
       };
-      config.footerTemplate = `<div style="width: 100%; background-color: #fff; font-size: 9px; text-align: center; padding: 5px 0 0 0; font-family: Arial; color: #444;">${FOOTER_TEMPLATE}</div>`;
+      config.footerTemplate = `
+      <style>
+      ${CUSTOM_CSS}
+      </style>
+      <div style="width: 100%; background-color: #fff; font-size: 9px; text-align: center; padding: 5px 0 0 0; font-family: Arial; color: #444;">
+      ${FOOTER_TEMPLATE}
+      </div>`;
     }
 
     if (IS_PAGE_NUMBER_VISIBLE) {

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -154,6 +154,14 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
             left: 0;
             right: 0;
             background-color: #fff;
+            width: 100%; 
+            background-color: #fff; 
+            font-size: 9px; 
+            text-align: 
+            center; 
+            padding: 5px 0 0 0; 
+            font-family: Arial; 
+            color: #444;
           }
   
           .page-header {

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -117,7 +117,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       }));
     });
 
-    const { FOOTER_TEMPLATE, HAS_FOOTER, FOOTER_H } = await page.evaluate((addedStyle) => {
+    const { FOOTER_TEMPLATE, HAS_FOOTER, FOOTER_H, CUSTOM_CSS } = await page.evaluate((addedStyle) => {
 
       const SBECCO = 20;
 
@@ -284,7 +284,8 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       return {
         FOOTER_TEMPLATE,
         HAS_FOOTER,
-        FOOTER_H
+        FOOTER_H,
+        CUSTOM_CSS
       };
     }, apiCss);
 

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -332,7 +332,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       <style>
       ${CUSTOM_CSS}
       </style>
-      <div style="width: 100%; background-color: #fff; font-size: 9px; text-align: center; padding: 5px 0 0 0; font-family: Arial; color: #444;">
+      <div class="page-footer">
       ${FOOTER_TEMPLATE}
       </div>`;
     }


### PR DESCRIPTION
## Esigenza del fix:
A seguito dello sviluppo di applicazione di un CSS custom da parte dell’utente ci siamo accorti che non viene applicato nessun CSS alla sezione footer del report a differenza della sezione header e body che viene correttamente applicato.

Si chiede quindi di:

Sistemare l’applicazione del CSS anche nel footer così come avviene nell’header e nel body
Cosa comprende questa pr:
aggiunta funzione per iniettare il footer proveniente dal client nel template del report con blocco condizionale: addFooter()
rimossa configurazione del footer del puppeteer tramite api del puppeteer
aggiunto stile dichiarato inline durante la costruzione del footer tramite api del puppeteer in classe .page-footer
formattazione files

---

## Cosa comprende questa pr:

Il frammento del footer semplice, essendo definito tramite le api di `page.pdf()` del puppeteer, non può comunicare con le altre risorse esterne - siano esse stylesheets oppure frammenti del dom come quello definito all'interno di `await page.evaluate` a riga 124. Anche l'import dello stile aggiunto tramite `page.addStyleTag()` a riga 349 non sembra funzionare. Ciò è probabilmente dovuto ad un bug proprio della libreria, come segnalato dagli issues che riporto di seguito:
- [footerTemplate and headerTemplate don't use body styles](https://github.com/puppeteer/puppeteer/issues/1853)
- [Scripts are not evalutated in header and footer HTML templates for PDFs.](https://github.com/puppeteer/puppeteer/issues/2167#event-645755896)
- [Full CSS Style support in header and footer html and Loading external Resources](https://github.com/puppeteer/puppeteer/issues/4254)

Pertanto, in attesa di poter studiare una soluzione più elegante adattabile anche al footer con una paginazione dei fogli di stampa, ho 
- aggiunto degli ulteriori tag style che replichino lo stile css definito all'interno di `await page.evaluate` a riga 124
- importato al suo interno lo stile dichiarato nella costante `CUSTOM_CSS`
- sostituito lo stile inline con la classe `.page-footer` 

  ---
  ## Files modificati:
  - server/lib/printer.js