### PR TITLE
feat: correzione directive per allegare immagini della galleria documenti (Rif.Int. 2026/ 34)

### DIFF
--- a/server/public/app.js
+++ b/server/public/app.js
@@ -116,10 +116,13 @@
             const promises = [];
 
             const vistaRowsPromisesList = visteDataService.getVistaRowsPromisesList(idViste, intIdRecord, visteCorrelate);
-            const schedaRowsPromise = campiSchedaService.getCampiSchedaObject({ infoScheda, idRecord: intIdRecord, idScheda });
-
             promises.push(...vistaRowsPromisesList);
-            promises.push(schedaRowsPromise);
+            
+            if (idScheda && infoScheda) {             
+              const schedaRowsPromise = campiSchedaService.getCampiSchedaObject({ infoScheda, idRecord: intIdRecord, idScheda });
+              promises.push(schedaRowsPromise);
+            } 
+            
             if (promises.length) {
               return Promise.all(promises);
             }

--- a/server/public/modules/report/directives/attachGalleriaReport.js
+++ b/server/public/modules/report/directives/attachGalleriaReport.js
@@ -29,10 +29,12 @@
 
   window.angular.module('reportApp.report')
     .directive('attachGalleriaReport', [
+      '$location',
       '$compile',
       'handleIdRecordsParams',
       'xdbApiService',
       'filesPerCampo', function (
+        $location,
         $compile,
         handleIdRecordsParams,
         xdbApiService,
@@ -44,55 +46,57 @@
             attachGalleriaReport: '=',
             record: '='
           },
-          link: function ($scope, $element) {
-            const url = new URL(window.location.href);
-            const searchParams = url.searchParams;
-            const idRecordParam = searchParams.get('idRecord');
+          link: function ($scope, $element, attributes) {
+
+            const searchParams = $location.search();
+            const idRecordParam = searchParams?.idRecord;
             const idRecordVistaInt = handleIdRecordsParams.getIntIdRecord(idRecordParam);
             const idRecordVistaList = handleIdRecordsParams.getArrayIdRecords(idRecordParam);
 
-            const idVista = $scope.attachGalleriaReport;
-            const {
-              filtro,
-              campo,
-              risorsa
-            } = $element[0].dataset;
+            const digest = () => {
+              if (!!scope.$$phase) return;
 
-            // const idRecord = $scope.record || idRecordVistaInt;
-
-            const digest = () => { 
-              if (scope.$$phase) return;
-                
               $scope.$parent.$digest();
             };
 
             const updateImgElement = ({ idRecordVista }) => {
-              return loadImages({
-                idVista,
-                idRecord: idRecordVista,
-                nomeRisorsa: risorsa,
-                foreignKeyVista: filtro,
-                xdbApiService,
-                filesPerCampo,
-                idCampo: campo
-              })
-                .then(images => {
-                const div = document.createElement('div');
-                div.className = 'report-gallery';
-                for (let index = 0; index < images.length; index++) {
-                  const container = document.createElement('div');
-                  container.className = 'report-gallery__image-container';
-                  const element = images[index];
-                  const caption = document.createElement('p');
-                  caption.className = 'report-gallery__caption';
-                  caption.innerText = `Immagine ${index + 1}`;
-                  container.appendChild(element);
-                  container.appendChild(caption);
-                  div.appendChild(container);
-                }
+              try {
 
-                  return angular.element(div);
+                if ([attributes?.attachGalleriaReport,
+                attributes?.risorsa,
+                attributes?.campo].some((data) => !data)) throw new Error(`Parametri mancanti: \n {\n attachGalleriaReport: ${attributes?.attachGalleriaReport},\n risorsa: ${attributes?.risorsa}, \n filtro: ${attributes?.filtro}, \n campo: ${attributes?.campo} \n}`);
+
+                return loadImages({
+                  idVista: attributes?.attachGalleriaReport,
+                  idRecord: idRecordVista,
+                  nomeRisorsa: attributes?.risorsa,
+                  foreignKeyVista: attributes?.filtro,
+                  xdbApiService,
+                  filesPerCampo,
+                  idCampo: attributes?.campo
                 })
+                  .then(images => {
+                    const div = document.createElement('div');
+                    div.className = 'report-gallery';
+
+                    for (let index = 0; index < images.length; index++) {
+                      const container = document.createElement('div');
+                      container.className = 'report-gallery__image-container';
+                      const element = images[index];
+                      const caption = document.createElement('p');
+                      caption.className = 'report-gallery__caption';
+                      caption.innerText = `Immagine ${index + 1}`;
+                      container.appendChild(element);
+                      container.appendChild(caption);
+                      div.appendChild(container);
+                    }
+
+                    return angular.element(div);
+                  })
+              } catch (error) {
+                console.error(error?.message);
+                return;
+              }
             };
 
             if (!Number.isInteger($scope?.record) && idRecordVistaList?.length > 0) {

--- a/server/public/modules/report/directives/attachGalleriaReport.js
+++ b/server/public/modules/report/directives/attachGalleriaReport.js
@@ -42,6 +42,7 @@
       ) {
         return {
           restrict: 'A',
+          transclude: true,
           scope: {
             attachGalleriaReport: '=',
             record: '='
@@ -59,7 +60,7 @@
               $scope.$parent.$digest();
             };
 
-            const updateImgElement = ({ idRecordVista }) => {
+            const createNewElement = ({ idRecordVista }) => {
               try {
 
                 if ([attributes?.attachGalleriaReport,
@@ -99,48 +100,58 @@
               }
             };
 
-            if (!Number.isInteger($scope?.record) && idRecordVistaList?.length > 0) {
-              return idRecordVistaList.forEach((idR, index) => { 
-                if (index > 0) { 
-                  return updateImgElement({ idRecordVista: idR })
-                    .then((newEl) => {
-                      const parent = angular.element($element.parent());
-                      const clone = angular.element($element.clone(true));
+            // wrappare tutto in scope.$watch? y/n
 
-                      clone.appendTo(parent);
-                      clone.replaceWith($compile(newEl)($scope));
-                  })
-                  .finally(() => {
-                    digest();
-                  });
-                }
-                
-                return updateImgElement({ idRecordVista: idR })
-                  .then((newEl) => {
-                    $element.append($compile(newEl)($scope));
-                  })
-                  .finally(() => {
-                    digest();
-                  });
-              });
-            }
+            // non c'è bisogno di fare questa catena di ifs 
+            // Meglio fare 3 callbacks separate e poi un'unica fn con switch, od object + if
 
-            if (!Number.isInteger($scope?.record) && !idRecordVistaList?.length) {
-              return updateImgElement({ idRecordVista: idRecordVistaInt })
+            const compileFromAttrsValue = () => {
+              return createNewElement({ idRecordVista: record })
                 .then((newEl) => {
                   $element.append($compile(newEl)($scope));
                 })
-                .finally(() => {  
-                 digest();
-                });
-            }
+                .finally(() => {
+                  digest();
+                })
+            };
 
-            updateImgElement({ idRecordVista: $scope.record }).then((newEl) => {
+            const compileFromParamList = async () => {
+              try {
+
+              if (!idRecordVistaList?.length) throw new Error("Non è associato più di un id record al search param idRecord");
+
+              const parentEl = $element.parent();
+              const firstIdRecord = idRecordVistaList[0];
+              const followingIds = idRecordVistaList.splice(1, idRecordVistaList.length); 
+
+                  const firstImage = await createNewElement({ idRecordVista: firstIdRecord });
+                  const followingImages = followingIds.map(async (idRecord) => {
+                    return await createNewElement({idRecordVista: idRecord})
+                  });
+
+                  $element.replaceWith($compile(firstImage)($scope)); 
+                  followingImages.forEach(async (element) => {
+                    parentEl.append($compile(element)($scope));
+                  })
+                } catch (error) {
+                  console.error(error?.message);
+
+                  return;
+                } finally {
+                  digest();
+                }
+              };
+
+            const compileFromParamValue = () => {
+              return createNewElement({ idRecordVista: idRecordVistaInt })
+                .then((newEl) => {
                   $element.append($compile(newEl)($scope));
                 })
-                .finally(() => {  
-                 digest();
+                .finally(() => {
+                  digest();
                 });
+            };
+            
           }
         };
       }]);

--- a/server/public/modules/report/directives/attachGalleriaReport.js
+++ b/server/public/modules/report/directives/attachGalleriaReport.js
@@ -29,8 +29,10 @@
 
   window.angular.module('reportApp.report')
     .directive('attachGalleriaReport', [
+      'handleIdRecordsParams',
       'xdbApiService',
       'filesPerCampo', function (
+        handleIdRecordsParams,
         xdbApiService,
         filesPerCampo
       ) {
@@ -43,7 +45,9 @@
           link: function ($scope, $element) {
             const url = new URL(window.location.href);
             const searchParams = url.searchParams;
-            const _idRecord = parseInt(searchParams.get('idRecord'), 10);
+            const idRecordParam = searchParams.get('idRecord');
+            const idRecordVistaInt = handleIdRecordsParams.getIntIdRecord(idRecordParam);
+            const idRecordVistaList = handleIdRecordsParams.getArrayIdRecords(idRecordParam);
 
             const idVista = $scope.attachGalleriaReport;
             const {
@@ -52,7 +56,7 @@
               risorsa
             } = $element[0].dataset;
 
-            const idRecord = $scope.record || _idRecord;
+            // const idRecord = $scope.record || idRecordVistaInt;
 
             loadImages({
               idVista,

--- a/server/public/modules/report/directives/attachGalleriaReport.js
+++ b/server/public/modules/report/directives/attachGalleriaReport.js
@@ -29,9 +29,11 @@
 
   window.angular.module('reportApp.report')
     .directive('attachGalleriaReport', [
+      '$compile',
       'handleIdRecordsParams',
       'xdbApiService',
       'filesPerCampo', function (
+        $compile,
         handleIdRecordsParams,
         xdbApiService,
         filesPerCampo
@@ -58,31 +60,83 @@
 
             // const idRecord = $scope.record || idRecordVistaInt;
 
-            loadImages({
-              idVista,
-              idRecord,
-              nomeRisorsa: risorsa,
-              foreignKeyVista: filtro,
-              xdbApiService,
-              filesPerCampo,
-              idCampo: campo
-            }).then(images => {
-              const div = document.createElement('div');
-              div.className = 'report-gallery';
-              for (let index = 0; index < images.length; index++) {
-                const container = document.createElement('div');
-                container.className = 'report-gallery__image-container';
-                const element = images[index];
-                const caption = document.createElement('p');
-                caption.className = 'report-gallery__caption';
-                caption.innerText = `Immagine ${index + 1}`;
-                container.appendChild(element);
-                container.appendChild(caption);
-                div.appendChild(container);
-              }
+            const digest = () => { 
+              if (scope.$$phase) return;
+                
+              $scope.$parent.$digest();
+            };
 
-              $element[0].replaceWith(div);
-            });
+            const updateImgElement = ({ idRecordVista }) => {
+              return loadImages({
+                idVista,
+                idRecord: idRecordVista,
+                nomeRisorsa: risorsa,
+                foreignKeyVista: filtro,
+                xdbApiService,
+                filesPerCampo,
+                idCampo: campo
+              })
+                .then(images => {
+                const div = document.createElement('div');
+                div.className = 'report-gallery';
+                for (let index = 0; index < images.length; index++) {
+                  const container = document.createElement('div');
+                  container.className = 'report-gallery__image-container';
+                  const element = images[index];
+                  const caption = document.createElement('p');
+                  caption.className = 'report-gallery__caption';
+                  caption.innerText = `Immagine ${index + 1}`;
+                  container.appendChild(element);
+                  container.appendChild(caption);
+                  div.appendChild(container);
+                }
+
+                  return angular.element(div);
+                })
+            };
+
+            if (!Number.isInteger($scope?.record) && idRecordVistaList?.length > 0) {
+              return idRecordVistaList.forEach((idR, index) => { 
+                if (index > 0) { 
+                  return updateImgElement({ idRecordVista: idR })
+                    .then((newEl) => {
+                      const parent = angular.element($element.parent());
+                      const clone = angular.element($element.clone(true));
+
+                      clone.appendTo(parent);
+                      clone.replaceWith($compile(newEl)($scope));
+                  })
+                  .finally(() => {
+                    digest();
+                  });
+                }
+                
+                return updateImgElement({ idRecordVista: idR })
+                  .then((newEl) => {
+                    $element.append($compile(newEl)($scope));
+                  })
+                  .finally(() => {
+                    digest();
+                  });
+              });
+            }
+
+            if (!Number.isInteger($scope?.record) && !idRecordVistaList?.length) {
+              return updateImgElement({ idRecordVista: idRecordVistaInt })
+                .then((newEl) => {
+                  $element.append($compile(newEl)($scope));
+                })
+                .finally(() => {  
+                 digest();
+                });
+            }
+
+            updateImgElement({ idRecordVista: $scope.record }).then((newEl) => {
+                  $element.append($compile(newEl)($scope));
+                })
+                .finally(() => {  
+                 digest();
+                });
           }
         };
       }]);

--- a/server/public/modules/report/directives/attachGalleriaReport.js
+++ b/server/public/modules/report/directives/attachGalleriaReport.js
@@ -56,14 +56,17 @@
 
             const createNewElement = function (imagesData) {
               const div = document.createElement('div');
-              div.className = 'report-gallery report-gallery__image-container';
+              div.className = 'report-gallery';
               for (let index = 0; index < imagesData.length; index++) {
+                const container = document.createElement('div');
+                container.className = 'report-gallery__image-container';
                 const element = imagesData[index];
                 const caption = document.createElement('p');
                 caption.className = 'report-gallery__caption';
                 caption.innerText = `Immagine ${index + 1}`;
-                div.appendChild(element);
-                div.appendChild(caption);
+                container.appendChild(element);
+                container.appendChild(caption);
+                div.appendChild(container);
               }
 
               return div;
@@ -115,9 +118,9 @@
                 filesPerCampo,
                 idCampo: campo
               }).then(images => {
-                const div = createNewElement(images);
+                const imageDiv = createNewElement(images);
 
-                $element.append($compile(angular.element(div))($scope));
+                $element.append($compile(angular.element(imageDiv))($scope));
               });
             };
 

--- a/server/public/modules/report/directives/attachGalleriaReport.js
+++ b/server/public/modules/report/directives/attachGalleriaReport.js
@@ -29,137 +29,116 @@
 
   window.angular.module('reportApp.report')
     .directive('attachGalleriaReport', [
-      '$location',
       '$compile',
-      'handleIdRecordsParams',
       'xdbApiService',
       'filesPerCampo', function (
-        $location,
         $compile,
-        handleIdRecordsParams,
         xdbApiService,
         filesPerCampo
       ) {
         return {
           restrict: 'A',
+          transclude: true,
           scope: {
             attachGalleriaReport: '=',
             record: '='
           },
-          link: function ($scope, $element, attributes) {
+          link: function ($scope, $element) {
+            const infoBase = $scope.$parent.infoBase;
+            const shouldHandleManyIds = !$scope.record && infoBase?.idRecords?.length > 0;
 
-            const searchParams = $location.search();
-            const idRecordParam = searchParams?.idRecord;
-            const idRecordVistaInt = handleIdRecordsParams.getIntIdRecord(idRecordParam);
-            const idRecordVistaList = handleIdRecordsParams.getArrayIdRecords(idRecordParam);
+            const idVista = $scope.attachGalleriaReport;
+            const {
+              filtro,
+              campo,
+              risorsa
+            } = $element[0].dataset;
 
-            const digest = () => {
-              if (!scope.$$phase) {
-                scope.$parent.$digest();
+            const createNewElement = function (imagesData) {
+              const div = document.createElement('div');
+              div.className = 'report-gallery report-gallery__image-container';
+              for (let index = 0; index < imagesData.length; index++) {
+                const element = imagesData[index];
+                const caption = document.createElement('p');
+                caption.className = 'report-gallery__caption';
+                caption.innerText = `Immagine ${index + 1}`;
+                div.appendChild(element);
+                div.appendChild(caption);
               }
+
+              return div;
             };
 
-            const createNewElement = ({ idRecordVista }) => {
-              try {
+            const replaceWithManyEls = function () {
+              const idRecords = infoBase?.idRecords || Array.from({ length: 0 });
 
-                if ([attributes?.attachGalleriaReport,
-                attributes?.risorsa,
-                attributes?.campo].some((data) => !data)) throw new Error(`Parametri mancanti: \n {\n attachGalleriaReport: ${attributes?.attachGalleriaReport},\n risorsa: ${attributes?.risorsa}, \n filtro: ${attributes?.filtro}, \n campo: ${attributes?.campo} \n}`);
+              const container = document.createElement("div");
+              const style = "width: 100%; height: 100%; display: flex; padding: 5px; column-gap: 5px; overflow-x: hidden; flex-wrap: wrap;";
+              container.setAttribute("style", style);
 
+              const promisesList = idRecords?.map((id) => {
                 return loadImages({
-                  idVista: attributes?.attachGalleriaReport,
-                  idRecord: idRecordVista,
-                  nomeRisorsa: attributes?.risorsa,
-                  foreignKeyVista: attributes?.filtro,
+                  idVista,
+                  idRecord: id,
+                  nomeRisorsa: risorsa,
+                  foreignKeyVista: filtro,
                   xdbApiService,
                   filesPerCampo,
-                  idCampo: attributes?.campo
+                  idCampo: campo
                 })
-                  .then(images => {
-                    const div = document.createElement('div');
-                    div.className = 'report-gallery';
+                  .catch(() => { })
+                  .then((images) => {
+                    const imageDiv = createNewElement(images);
+                    imageDiv.setAttribute('id', `image-${id}-${risorsa}`);
 
-                    for (let index = 0; index < images.length; index++) {
-                      const container = document.createElement('div');
-                      container.className = 'report-gallery__image-container';
-                      const element = images[index];
-                      const caption = document.createElement('p');
-                      caption.className = 'report-gallery__caption';
-                      caption.innerText = `Immagine ${index + 1}`;
-                      container.appendChild(element);
-                      container.appendChild(caption);
-                      div.appendChild(container);
-                    }
-
-                    return angular.element(div);
+                    container.appendChild(imageDiv);
                   })
-              } catch (error) {
-                console.error(error?.message);
-                return  $element.clone();
-              }
-            };
+              });
 
-            // wrappare tutto in scope.$watch? y/n
-
-            const compileFromAttrsValue = () => {
-              return createNewElement({ idRecordVista: record })
-                .then((newEl) => {
-                  $element.append($compile(newEl)($scope));
-                })
-                .finally(() => {
-                  digest();
-                })
-            };
-
-            const compileFromParamList = async () => {
-              try {
-
-              if (!idRecordVistaList?.length) throw new Error("Non è associato più di un id record al search param idRecord");
-
-              const parentEl = $element.parent();
-              const firstIdRecord = idRecordVistaList[0];
-              const followingIds = idRecordVistaList.splice(1, idRecordVistaList.length); 
-
-                  const firstImage = await createNewElement({ idRecordVista: firstIdRecord });
-                  const followingImages = followingIds.map(async (idRecord) => {
-                    return await createNewElement({idRecordVista: idRecord})
-                  });
-
-                  $element.replaceWith($compile(firstImage)($scope)); 
-                  followingImages.forEach(async (element) => {
-                    parentEl.append($compile(element)($scope));
-                  })
-                } catch (error) {
-                  console.error(error?.message);
-
-                  return;
-                } finally {
-                  digest();
-                }
-              };
-
-            const compileFromParamValue = () => {
-              return createNewElement({ idRecordVista: idRecordVistaInt })
-                .then((newEl) => {
-                  $element.append($compile(newEl)($scope));
-                })
-                .finally(() => {
-                  digest();
+              return Promise.allSettled(promisesList)
+                .then((results) => {
+                  if (results.some((res) => res.status === "fulfilled")) {
+                    $element.append($compile(angular.element(container))($scope));
+                  }
                 });
             };
 
-            const shouldUseAttrValue = Number.isInteger(attributes?.record);
-            const shouldUseSingleParamVal = !shouldUseAttrValue && !infoBase?.idRecords?.length;
-            const shouldUseParamValues = !shouldUseAttrValue && infoBase?.idRecords?.length > 0;
-              
-              switch (true) {
-                case shouldUseParamValues:
-                  return compileFromParamList();
-                case shouldUseSingleParamVal:
-                  return compileFromParamValue();
-                default:
-                  return compileFromAttrsValue();
+            const replaceWithSingleEl = function () {
+              const idRecord = $scope.record || infoBase?.idRecord;
+
+              return loadImages({
+                idVista,
+                idRecord,
+                nomeRisorsa: risorsa,
+                foreignKeyVista: filtro,
+                xdbApiService,
+                filesPerCampo,
+                idCampo: campo
+              }).then(images => {
+                const div = createNewElement(images);
+
+                $element.append($compile(angular.element(div))($scope));
+              });
+            };
+
+            const insertNewElement = function (hasManyIds) {
+              if (hasManyIds) return replaceWithManyEls();
+
+              return replaceWithSingleEl();
+            };
+
+            $scope.$watch(() => $scope.$parent.loading, function (newVal, oldVal) {
+              if (!newVal && oldVal) {
+                $scope.$apply(
+                  insertNewElement(shouldHandleManyIds)
+                );
               }
+
+              if (newVal && !oldVal) {
+                $scope.$destroy();
+              }
+            }, true);
+
           }
         };
       }]);

--- a/server/public/modules/report/directives/attachGalleriaReport.js
+++ b/server/public/modules/report/directives/attachGalleriaReport.js
@@ -73,11 +73,12 @@
             };
 
             const replaceWithManyEls = function () {
-              const idRecords = infoBase?.idRecords || Array.from({ length: 0 });
+              const idRecords = infoBase?.idRecords;
 
-              const container = document.createElement("div");
-              const style = "width: 100%; height: 100%; display: flex; padding: 5px; column-gap: 5px; overflow-x: hidden; flex-wrap: wrap;";
-              container.setAttribute("style", style);
+              const imageContainerStyle = `width: 100%; height: 100%; padding: 5px; display: grid; grid-template-columns: repeat(auto-fill, minmax(${Math.floor((100 / (!idRecords?.length ? 1 : idRecords?.length)))}%, 100%)); grid-template-rows: repeat(${!idRecords?.length ? 1 : idRecords?.length}, 1fr); grid-gap: 0px;`;
+
+              const container = document.createElement("div")
+              container.setAttribute("style", imageContainerStyle);
 
               const promisesList = idRecords?.map((id) => {
                 return loadImages({
@@ -93,6 +94,8 @@
                   .then((images) => {
                     const imageDiv = createNewElement(images);
                     imageDiv.setAttribute('id', `image-${id}-${risorsa}`);
+
+                    if (!angular.isElement(imageDiv)) return;
 
                     container.appendChild(imageDiv);
                   })

--- a/server/public/modules/report/directives/attachGalleriaReport.js
+++ b/server/public/modules/report/directives/attachGalleriaReport.js
@@ -42,7 +42,6 @@
       ) {
         return {
           restrict: 'A',
-          transclude: true,
           scope: {
             attachGalleriaReport: '=',
             record: '='
@@ -55,9 +54,9 @@
             const idRecordVistaList = handleIdRecordsParams.getArrayIdRecords(idRecordParam);
 
             const digest = () => {
-              if (!!scope.$$phase) return;
-
-              $scope.$parent.$digest();
+              if (!scope.$$phase) {
+                scope.$parent.$digest();
+              }
             };
 
             const createNewElement = ({ idRecordVista }) => {
@@ -96,14 +95,11 @@
                   })
               } catch (error) {
                 console.error(error?.message);
-                return;
+                return  $element.clone();
               }
             };
 
             // wrappare tutto in scope.$watch? y/n
-
-            // non c'è bisogno di fare questa catena di ifs 
-            // Meglio fare 3 callbacks separate e poi un'unica fn con switch, od object + if
 
             const compileFromAttrsValue = () => {
               return createNewElement({ idRecordVista: record })
@@ -151,7 +147,19 @@
                   digest();
                 });
             };
-            
+
+            const shouldUseAttrValue = Number.isInteger(attributes?.record);
+            const shouldUseSingleParamVal = !shouldUseAttrValue && !infoBase?.idRecords?.length;
+            const shouldUseParamValues = !shouldUseAttrValue && infoBase?.idRecords?.length > 0;
+              
+              switch (true) {
+                case shouldUseParamValues:
+                  return compileFromParamList();
+                case shouldUseSingleParamVal:
+                  return compileFromParamValue();
+                default:
+                  return compileFromAttrsValue();
+              }
           }
         };
       }]);

--- a/server/public/modules/report/directives/avatarRecord.js
+++ b/server/public/modules/report/directives/avatarRecord.js
@@ -8,7 +8,7 @@
             link: {
                 post(scope, element, attrs, _controller, transclude) {
                     const { idScheda } = schedeDataStore.getData();
-                    const idRecord = scope.idRecord ?? scope.infoBase.idRecord;
+                    const idRecord = scope.infoBase.idRecord;
                     const idSchedaPerAvatar = parseInt(attrs.avatarRecord, 10) ?? idScheda;
                     const loading = scope.loading;
                     const isValidValue = (value) => value !== undefined && value !== null;

--- a/server/public/modules/report/directives/idRecord.js
+++ b/server/public/modules/report/directives/idRecord.js
@@ -16,7 +16,10 @@
                         transcludeFnScope = scope.$parent.$new();
                         Object.assign(transcludeFnScope, {
                             loading: newValue,
-                            idRecord,
+                            infoBase: {
+                                ...scope.$parent?.infoBase,
+                                idRecord,
+                            },
                         });
 
                         if (!newValue && oldValue) {

--- a/server/public/modules/report/directives/idRecord.js
+++ b/server/public/modules/report/directives/idRecord.js
@@ -38,6 +38,8 @@
                     };
 
                     const processSchedaPromise = ({ infoScheda, idScheda, scopeCopy }) => {
+                        if (!infoScheda || !idScheda) return;
+                        
                         return Promise.resolve(campiSchedaService.getCampiSchedaObject({ idRecord, idScheda, infoScheda }))
                             .then(function (schedaObj) {
                                 if (!Object.entries(schedaObj)?.length) return;

--- a/server/public/modules/report/directives/primaFotoReport.js
+++ b/server/public/modules/report/directives/primaFotoReport.js
@@ -8,7 +8,7 @@
             link: {
                 post(scope, element, attrs, _controller) {
                     const idFoto = parseInt(attrs.primaFotoReport, 10);
-                    const idRecord = scope.idRecord ?? scope.infoBase.idRecord;
+                    const idRecord = scope.infoBase.idRecord;
                     const nomeRisorsa = attrs.risorsa;
                     const idCampo = attrs.campo;
                     const filtroCampo = attrs.filtro;

--- a/server/public/modules/report/service/handleIdRecordsParams.js
+++ b/server/public/modules/report/service/handleIdRecordsParams.js
@@ -39,11 +39,7 @@
       if ((typeof idRecord == undefined) || (typeof idRecord == null)) {
         throw new Error('idRecord mancante', typeof idRecord);
       };
-
-      if (Array.isArray(idRecord)) {
-        return `=%25IN=${idRecord.toString()}`;
-      }
-
+      
       return `=%25=${idRecord}`;
     };
   };


### PR DESCRIPTION
## Esigenza del fix: 

Modificare la gestione del dato idRecord di una vista impatta anche sull’inserimento all’interno di un report delle immagini provenienti dalla galleria documenti allegati. Infatti, la directive responsabile di ciò gestisce questo dato aspettandosi ancora il vecchio formato.

Quindi, è necessario adattarne il codice per garantirne il corretto funzionamento.

---

## Cosa comprende questa pr:

<u>In `attachGalleriaReport.js`:</u>
1. ereditato $scope dal componente padre così da poter riutilizzare i valori di  \$scope.infoBase.idRecord e \$scope.infoBase.idRecords , quindi:
2. sostituito i valori provenienti dai search params dell'url con i suddetti per evitare errori di sincronia e duplicazione del codice
3. suddiviso il processo sovrascrittura dell'elemento in cui la directive è in uso in 3 fasi, ognuna con la propria callback indipendente. 
	1. `createNewElement`: crea nuovo elemento da inserire nel dom con i dati  ricavati da loadImages  
	2. `replaceWithSingleEl`: usa loadImages con un solo idRecord, che può provenire dagli attributi del componente angular oppure dallo scope padre,  e sostituisce il componente ricavato con quello su cui agisce la directive 
	3. `replaceWithManyEls`: usa un array di `loadImages` con un solo idRecord per volta, il quale proviene dall'array idRecords nell'oggetti infoBase dello scope padre. Inserisce  ogni elemento ricavato in un elemento contenitore che verrà poi sostituito  al componente su cui agisce la directive  
	4. `insertNewElement`: decide quale funzione lanciare tra replaceWithManyEls e `replaceWithSingleEl` in base alla presenza (o assenza) di idRecords
4. sfruttato il ciclo di vita dello \$scope per ricompilare il DOM
5. Inserito dello stile al div contenitore di immagini derivanti dal dato `infoBase.idRecords` così che rappresenti le serie di immagini all'interno di una griglia con numero di colonne e righe variabili

<u>In `idRecord.js`:</u>
1. aggiunto proprietà `infoBase: {...}` allo \$scope oer evitare conflitti con pezzi di codice che, pur ricevendo idRecord multipli  e usando (o derivando da elementi che usano) la directive, cercano il dato  `infoBase.idRecord`.
Aggiornato le directives `avatarRecord.js` e `primaFotoReport.js` di conseguenza.

<u>In `idRecord.js` e `app.js`:</u>
1. Aggiunto controllo per non lanciare `campiSchedaService.getCampiSchedaObject` quando i parametri `infoScheda` e `idScheda` risultano nulli o non definiti

<u>In handlerecordsparams.js:</u>
1. eliminato searchParam scorretto per id multipli . 
   Quando validateIdRecordParam riceveva come parametro un idRecord di tipo number[], restituiva una stringa da inserire nei searchParams dell'url della GET per  data/viste-row di tipo `=%25IN=${idRecord.toString()}`. Poiché le api sono  cambiate da quando è stata fatta questa scelta, questo caso è stato  rimosso.