### PR TITLE
fix: applicazione stili nel footer (Rif.Int.: 2025/4927 e 2025/4928) 

### DIFF
--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -133,6 +133,10 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
 
       const getCustomCSS = function (headerHeight, addedStyle) {
         const CUSTOM_CSS = `
+          html {
+              -webkit-print-color-adjust: exact;
+            }
+
           .document-preview__frame__page-break-after {
             width: 100%;
             border: none;
@@ -147,13 +151,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
             height: ${headerHeight ? headerHeight + SBECCO : '0'}px;
           }
   
-  
           .page-footer {
-            position: fixed;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background-color: #fff;
             width: 100%; 
             background-color: #fff; 
             font-size: 9px; 
@@ -163,7 +161,21 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
             font-family: Arial; 
             color: #444;
           }
+
+          .page-footer--fixed {
+            position: fixed;
+            bottom: 0px;
+            left: 0;
+            right: 0;
+          }
   
+          .page-footer--with-numbers {
+            display: flex; 
+            flex-direction: column; 
+            align-items: center; 
+            justify-content: center;
+          }
+
           .page-header {
             position: fixed;
             top: 0mm;
@@ -188,6 +200,10 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
           }
   
           @media print {
+            html {
+              -webkit-print-color-adjust: exact;
+            }
+
             thead {display: table-header-group;} 
             tfoot {display: table-footer-group;}
             button {display: none;}
@@ -216,11 +232,11 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
           `;
         return CUSTOM_CSS;
       };
-            
+
       const CUSTOM_CSS = getCustomCSS(HEADER_H, addedStyle);
 
       const getHTMLReportFromContent = function (bodyHTML, headerHTML) {
-        
+
         return `
         <style>${CUSTOM_CSS}</style>
             <div id="header" class="page-header">
@@ -326,27 +342,33 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
         top: 0,
         right: 0,
         left: 0,
-        bottom: FOOTER_H || 40
+        bottom: FOOTER_H + 40 || 40
       };
+      config.printBackground = true;
       config.footerTemplate = `
       <style>
       ${CUSTOM_CSS}
       </style>
-      <div class="page-footer">
+      <div class="page-footer page-footer--fixed">
       ${FOOTER_TEMPLATE}
       </div>`;
     }
 
     if (IS_PAGE_NUMBER_VISIBLE) {
+      config.displayHeaderFooter = true;
       config.margin = {
         top: 0,
         right: 0,
         left: 0,
-        bottom: FOOTER_H ? FOOTER_H + 40 : 40
+        bottom: HAS_FOOTER ? FOOTER_H + 40 : 40
       };
-      config.footerTemplate = `<div style="width: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center;">
-        ${config.footerTemplate}
-        <div style="width: 100%; margin-top: 10px; font-size: 9px; text-align: center; padding: 5px 0 0 0; font-family: Arial; color: #444;">
+      config.printBackground = true;
+      config.footerTemplate = `<style>
+        ${CUSTOM_CSS}
+      </style>
+      <div class="page-footer page-footer--with-numbers page-footer--fixed">
+        ${!HAS_FOOTER ? "" : FOOTER_TEMPLATE}
+        <div id="page-numbers-container" class="page-footer">
           Pagina <span class="pageNumber"></span> di <span class="totalPages"></span>
         </div>
       </div>`;

--- a/server/lib/printer.js
+++ b/server/lib/printer.js
@@ -117,7 +117,7 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       }));
     });
 
-    const { FOOTER_TEMPLATE, HAS_FOOTER, FOOTER_H } = await page.evaluate((addedStyle) => {
+    const { FOOTER_TEMPLATE, HAS_FOOTER, FOOTER_H, CUSTOM_CSS } = await page.evaluate((addedStyle) => {
 
       const SBECCO = 20;
 
@@ -154,6 +154,14 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
             left: 0;
             right: 0;
             background-color: #fff;
+            width: 100%; 
+            background-color: #fff; 
+            font-size: 9px; 
+            text-align: 
+            center; 
+            padding: 5px 0 0 0; 
+            font-family: Arial; 
+            color: #444;
           }
   
           .page-header {
@@ -284,7 +292,8 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
       return {
         FOOTER_TEMPLATE,
         HAS_FOOTER,
-        FOOTER_H
+        FOOTER_H,
+        CUSTOM_CSS
       };
     }, apiCss);
 
@@ -319,7 +328,13 @@ const create = async ({ timeout, logger, networkLogging, cluster }) => {
         left: 0,
         bottom: FOOTER_H || 40
       };
-      config.footerTemplate = `<div style="width: 100%; background-color: #fff; font-size: 9px; text-align: center; padding: 5px 0 0 0; font-family: Arial; color: #444;">${FOOTER_TEMPLATE}</div>`;
+      config.footerTemplate = `
+      <style>
+      ${CUSTOM_CSS}
+      </style>
+      <div class="page-footer">
+      ${FOOTER_TEMPLATE}
+      </div>`;
     }
 
     if (IS_PAGE_NUMBER_VISIBLE) {


### PR DESCRIPTION
### Descrizione intervento 2025-4927:

A seguito dello sviluppo di applicazione di un CSS custom da parte dell’utente ci siamo accorti che non viene applicato nessun CSS alla sezione footer del report a differenza della sezione header e body che viene correttamente applicato.

Si chiede quindi di:

- Sistemare l’applicazione del CSS anche nel footer così come avviene nell’header e nel body

### Descrizione intervento 2025-4928:

Nel progetto del puppeteer, durante la costruzione della pagina in caso di visualizzazione del numero di pagina nel report viene applicato un blocco html così composto:

``` javascript
 // printer.js row 325
if (IS_PAGE_NUMBER_VISIBLE) {
      config.margin = {
        top: 0,
        right: 0,
        left: 0,
        bottom: FOOTER_H ? FOOTER_H + 40 : 40
      };
      config.footerTemplate = `<div style="width: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center;">
        ${config.footerTemplate}
        <div style="width: 100%; margin-top: 10px; font-size: 9px; text-align: center; padding: 5px 0 0 0; font-family: Arial; color: #444;">
          Pagina <span class="pageNumber"></span> di <span class="totalPages"></span>
        </div>
      </div>`;
    }
```

Siccome ci viene chiesto di poter spostare il posizionamento del numero di pagina (attualmente viene messo sempre al centro della pagina) si può provare una soluzione del genere:

- Racchiudere tutto lo stile in-line del `<div>` contenente il numero di pagina in una classe specifica all’interno del puppeteer

Verifiche post sviluppo:

- Provare nella configurazione del report a sovrascrivere il posizionamento del numero di pagina attraverso un CSS custom

---
## Cosa comprende questa pr: 

- Contenuto del branch (rimosso) [fix/rimozione-stile-inline-footer](https://github.com/sinapsidev/puppeteer-report/pull/10)
- Contenuto del branch (rimosso) [fix/applicazione-css-footer](https://github.com/sinapsidev/puppeteer-report/pull/11)