### PR TITLE
fix(style-source): imposta il dominio di produzione come origine per lo stylesheet

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -12,7 +12,7 @@
     <link
         href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Symbols+Outlined|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp"
         rel="stylesheet">
-    <link id="main-css" rel="stylesheet" href="https://logicawebdev2.snps.it/assets/css/app.css">
+    <link id="main-css" rel="stylesheet" href="https://app.logicasolutions.it/assets/css/app.css">
 
     <script src="./assets/angular/angular.min.js"></script>
     <script src="./assets/angular-cookies/angular-cookies.min.js"></script>


### PR DESCRIPTION
Imposta il dominio di produzione come origine per lo stylesheet.
Prima l'origine era il dominio di dev, che però non è raggiungibile al di fuori di una determinata fascia oraria.

Refs: Int. 2026/2482